### PR TITLE
[#881] [#904] list virtualization for issues

### DIFF
--- a/apps/projects/app/components/Card/Issue.js
+++ b/apps/projects/app/components/Card/Issue.js
@@ -41,7 +41,7 @@ const labelsBadges = labels =>
 
 class Issue extends React.PureComponent {
   render() {
-    const { isSelected, onClick, onSelect, ...issue } = this.props
+    const { isSelected, onClick, onSelect, style, ...issue } = this.props
 
     const {
       workStatus,
@@ -56,7 +56,7 @@ class Issue extends React.PureComponent {
     } = issue
 
     return (
-      <StyledIssue>
+      <StyledIssue style={style}>
         <div style={{ padding: '10px' }}>
           <Checkbox checked={isSelected} onChange={() => onSelect(issue)} />
         </div>
@@ -135,6 +135,7 @@ Issue.propTypes = {
     'fulfilled',
   ]),
   work: PropTypes.oneOf([ undefined, PropTypes.object ]),
+  style: PropTypes.object,
 }
 
 const StyledIssue = styled.div`
@@ -149,9 +150,11 @@ const StyledIssue = styled.div`
   position: relative;
   :first-child {
     border-radius: 3px 3px 0 0;
+    border-top: 0px;
   }
   :last-child {
     border-radius: 0 0 3px 3px;
+    border-bottom: 0px;
   }
 `
 const IssueTitleDetailsBalance = styled.div`

--- a/apps/projects/app/components/Content/Issues.js
+++ b/apps/projects/app/components/Content/Issues.js
@@ -15,7 +15,7 @@ import Unauthorized from './Unauthorized'
 import ActionsMenu from './ActionsMenu'
 
 import {
-  List,
+  List as VirtualizedList,
   CellMeasurer,
   CellMeasurerCache,
   AutoSizer
@@ -395,7 +395,7 @@ class Issues extends React.PureComponent {
   */
   flattenIssues = data => {
     let downloadedIssues = []
-    let downloadedRepos = {}
+    const downloadedRepos = {}
 
     Object.keys(data).forEach(nodeName => {
       const repo = data[nodeName]
@@ -546,15 +546,6 @@ class Issues extends React.PureComponent {
                 >
                   {({ height }) => (
                     <List
-                      style={{
-                        borderTopWidth: '1px',
-                        borderTopStyle: 'solid',
-                        borderTopColor: theme.contentBorder,
-                        borderBottomWidth: '1px',
-                        borderBottomStyle: 'solid',
-                        borderBottomColor: theme.contentBorder,
-                        borderRadius: '3px'
-                      }}
                       autoWidth={true}
                       width={window.innerWidth}
                       height={height}
@@ -593,6 +584,12 @@ const IssuesScrollView = styled.div`
   flex-direction: column;
   justify-content: stretch;
   flex-grow: 1;
+`
+
+const List = styled(VirtualizedList)`
+  border-top: 1px solid ${theme.contentBorder};
+  border-bottom: 1px solid ${theme.contentBorder};
+  border-radius: 3px;
 `
 
 const recursiveDeletePathFromObject = (path, object) => {

--- a/apps/projects/app/index.html
+++ b/apps/projects/app/index.html
@@ -2,10 +2,18 @@
 <html>
   <head>
     <title>Projects App</title>
+    <style>
+      #projects > div {
+          height: 100%;
+      }
+      div[class^="AppView__Content"] {
+          height: 100%;
+      }
+    </style>
   </head>
 
   <body>
-    <div id="projects" style="overflow: hidden"></div>
+    <div id="projects" style="overflow: hidden; height: 100%"></div>
     <script src="index.js"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   },
   "dependencies": {
     "ipfs-http-client": "29.1.0",
+    "react-virtualized": "^9.21.1",
     "rxjs": "^6.4.0",
     "rxjs-compat": "^6.4.0"
   }


### PR DESCRIPTION
closes #881
closes #904 

The issue list is displayed by means of a `react-virtualized` List. a [WindowScroller](https://github.com/bvaughn/react-virtualized/blob/master/docs/WindowScroller.md) HOC is used to adjust the external dimensions of the List, while a [CellMeasurer](https://github.com/bvaughn/react-virtualized/blob/master/docs/CellMeasurer.md) HOC adjusts the height of each row according to its content's size. An `onScroll` event is used to calculate the appropriate moment to request more issues from the Github API.

Tested with a repo with 10,000+ issues (bulk issue generation script included). I only scrolled until issue 9,000 and got bored, but worked well. Sometimes it jumps a little when new issues are loaded.

The height of the list [is calculated](https://github.com/AutarkLabs/planning-suite/pull/1057/files#diff-1e61190978ae534ae80fe1f071b7e785R660) in a bad way, which isn't super responsive and may cause maintainability issues in the future. Also, in order to avoid refreshes, I included some [very](https://github.com/AutarkLabs/planning-suite/pull/1057/files#diff-1e61190978ae534ae80fe1f071b7e785R572) [inelegant](https://github.com/AutarkLabs/planning-suite/pull/1057/files#diff-1e61190978ae534ae80fe1f071b7e785R462) [checks](https://github.com/AutarkLabs/planning-suite/pull/1057/files#diff-1e61190978ae534ae80fe1f071b7e785R484).