### PR TITLE
Projects: cleanup getIssuesForRepos query

### DIFF
--- a/apps/projects/app/components/Panel/NewIssue/NewIssue.js
+++ b/apps/projects/app/components/Panel/NewIssue/NewIssue.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { Mutation } from 'react-apollo'
 import { useAragonApi } from '../../../api-react'
 import { Field, GU, TextInput, DropDown } from '@aragon/ui'
-import { NEW_ISSUE, GET_ISSUES } from '../../../utils/gql-queries.js'
+import { NEW_ISSUE } from '../../../utils/gql-queries.js'
 import { Form } from '../../Form'
 import { LoadingAnimation } from '../../Shared'
 import { usePanelManagement } from '../../Panel'
@@ -103,18 +103,12 @@ class NewIssue extends React.PureComponent {
 
     const id = selectedProject > 0 ? reposIds[selectedProject - 1] : ''
 
-    const reGet = [
-      {
-        query: GET_ISSUES,
-        variables: { reposIds },
-      },
-    ]
+    // TODO: refetch Issues list after mutation
 
     return (
       <div css={`margin: ${2 * GU}px 0`}>
         <Mutation
           mutation={NEW_ISSUE}
-          refetchQueries={reGet}
           variables={{ title, description, id }}
           onError={console.error}
         >

--- a/apps/projects/app/utils/gql-queries.js
+++ b/apps/projects/app/utils/gql-queries.js
@@ -33,57 +33,15 @@ const issueAttributes = `
   url
 `
 
-export const GET_ISSUES = gql`
-  query getIssuesForRepos($reposIds: [ID!]!) {
-    nodes(ids: $reposIds) {
-      ... on Repository {
-        issues(last: 100, states:OPEN) {
-          nodes {
-            number
-            id
-            title
-            body
-            createdAt
-            repository {
-              id
-              name
-            }
-            labels(first: 50) {
-              totalCount
-              edges {
-                node {
-                  id
-                  name
-                  color
-                }
-              }
-            }
-            milestone {
-              id
-              title
-            }
-            state
-            url
-          }
-        }
-      }
-    }
-  }
-`
-
 export const getIssuesGQL = repos => {
-  let q = `
-    query getIssuesForRepos {
-  `
-  Object.keys(repos).forEach((repoId, i) => {
-    q += 'node' + i + ': node(id: "' + repoId + `") {
+  const queries = Object.keys(repos).map((repoId, i) => `
+    node${i}: node(id: "${repoId}") {
       id
       ... on Repository {
         issues(
           states:OPEN,
-          first: ` + repos[repoId].fetch + ', ' +
-          (repos[repoId].showMore ? 'after: "' + repos[repoId].endCursor + '", ' : '') +
-          `
+          first: ${repos[repoId].fetch},
+          ${repos[repoId].showMore ? `after: "${repos[repoId].endCursor}",` : ''}
          orderBy: {field: CREATED_AT, direction: DESC}
         ) {
           totalCount
@@ -94,13 +52,11 @@ export const getIssuesGQL = repos => {
           nodes { ${issueAttributes} }
         }
       }
-    }
-    `
-  })
-  q += `
-}
-  `
-  return gql`${q}`
+    }`
+  )
+  return gql`query getIssuesForRepos {
+    ${queries.join('')}
+  }`
 }
 
 export const GET_ISSUE = gql`


### PR DESCRIPTION
* Remove obsolete GET_ISSUES
* Don't use temporary variable
* Restructure getIssuesGQL to make it easier to read