### PR TITLE
Allocations: Remove header on No budget page

### DIFF
--- a/apps/allocations/app/components/App/Accounts.js
+++ b/apps/allocations/app/components/App/Accounts.js
@@ -5,18 +5,13 @@ import styled from 'styled-components'
 import { Badge, Text, Viewport } from '@aragon/ui'
 
 import { CARD_STRETCH_BREAKPOINT } from '../../utils/responsive'
-import { Account, Empty } from '../Card'
+import { Account } from '../Card'
 
 const Accounts = ({
   accounts,
-  onNewAccount,
   onNewAllocation,
 }) => {
   if (!accounts) return
-
-  if (accounts.length === 0) {
-    return <Empty action={onNewAccount} />
-  }
 
   return (
     <Viewport>
@@ -51,7 +46,6 @@ const Accounts = ({
 Accounts.propTypes = {
   // TODO: Create account shape
   accounts: PropTypes.arrayOf(PropTypes.object).isRequired,
-  onNewAccount: PropTypes.func.isRequired,
   onNewAllocation: PropTypes.func.isRequired,
 }
 

--- a/apps/allocations/app/components/App/App.js
+++ b/apps/allocations/app/components/App/App.js
@@ -1,10 +1,12 @@
 import React, { useState } from 'react'
+import PropTypes from 'prop-types'
 
 import { useAragonApi } from '@aragon/api-react'
 import { Button, Header, IconPlus, Main, SidePanel } from '@aragon/ui'
 
 import { IdentityProvider } from '../../../../../shared/identity'
 import { NewAccount, NewAllocation } from '../Panel'
+import { Empty } from '../Card'
 import { Accounts, Payouts } from '.'
 
 const ASSETS_URL = './aragon-ui'
@@ -88,24 +90,13 @@ const App = () => {
 
   const PanelContent = panel ? panel.content : null
 
-  return (
-    // TODO: Profile App with React.StrictMode, perf and why-did-you-update, apply memoization
+  const Wrap = ({ children }) => (
     <Main assetsUrl={ASSETS_URL}>
-      <Header
-        primary="Allocations"
-        secondary={
-          <Button mode="strong" icon={<IconPlus />} onClick={onNewAccount} label="New Account" />
-        }
-      />
 
       <IdentityProvider
         onResolve={handleResolveLocalIdentity}
         onShowLocalIdentityModal={handleShowLocalIdentityModal}>
-        <Accounts
-          accounts={accounts}
-          onNewAccount={onNewAccount}
-          onNewAllocation={onNewAllocation}
-        />
+        { children }
         <Payouts
           payouts={payouts}
           executePayout={onExecutePayout}
@@ -121,6 +112,30 @@ const App = () => {
         </SidePanel>
       </IdentityProvider>
     </Main>
+  )
+
+  Wrap.propTypes = {
+    children: PropTypes.node.isRequired,
+  }
+
+  if (accounts.length === 0) {
+    return <Wrap><Empty action={onNewAccount} /></Wrap>
+  }
+
+  return (
+    // TODO: Profile App with React.StrictMode, perf and why-did-you-update, apply memoization
+    <Wrap>
+      <Header
+        primary="Allocations"
+        secondary={
+          <Button mode="strong" icon={<IconPlus />} onClick={onNewAccount} label="New Account" />
+        }
+      />
+      <Accounts
+        accounts={accounts}
+        onNewAllocation={onNewAllocation}
+      />
+    </Wrap>
   )
 }
 

--- a/apps/allocations/app/components/Card/Empty.js
+++ b/apps/allocations/app/components/Card/Empty.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { Button, EmptyStateCard, unselectable } from '@aragon/ui'
+import { Button, EmptyStateCard, GU, unselectable } from '@aragon/ui'
 import icon from '../../assets/empty-accounts.svg'
 
 const Icon = () => <img src={icon} alt="Empty accounts icon" />
@@ -28,6 +28,7 @@ const EmptyWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
+  height: calc(100vh - ${14 * GU}px);
 `
 
 export default Empty


### PR DESCRIPTION
In this PR, the `if no entries` logic is consolidated into the `App` component.

Previously, the `Empty` card was displayed inside `Accounts` whenever the number of accounts was zero. Now, since `Header` is an element at the same level of `Accounts`, the logic for displaying the `Empty` card, along with hiding the `Header` was moved up to their parent component, `App`. This is similar to what I did for Address Book. See the related discussion [here](https://github.com/AutarkLabs/open-enterprise/pull/1194#pullrequestreview-281662871).