### PR TITLE
Revert "Revert isValuePct to pure function at DotVotingMock"

### DIFF
--- a/apps/dot-voting/contracts/test/mocks/DotVotingMock.sol
+++ b/apps/dot-voting/contracts/test/mocks/DotVotingMock.sol
@@ -5,7 +5,7 @@ import "../../DotVoting.sol";
 
 contract DotVotingMock is DotVoting {
     // _isValuePct public wrapper
-    function isValuePct(uint256 _value, uint256 _total, uint256 _pct) external pure returns (bool) {
+    function isValuePct(uint256 _value, uint256 _total, uint256 _pct) external returns (bool) {
         return _isValuePct(_value, _total, _pct);
     }
 }


### PR DESCRIPTION
Reverts c455c190a730a6f96a15b76b5fd6af9929d2318c

We [thought][1] we did not need this change, but tests are failing without it.

  [1]: https://github.com/AutarkLabs/open-enterprise/pull/1196#pullrequestreview-283984650