### PR TITLE
Fix `npm run start:dev`

### DIFF
--- a/apps/address-book/app/api-react.js
+++ b/apps/address-book/app/api-react.js
@@ -6,6 +6,6 @@ const initialState = process.env.NODE_ENV !== 'production' && {
 const functions = process.env.NODE_ENV !== 'production' && ((appState, setAppState) => ({
 }))
 
-const { useAragonApi, useNetwork } = buildStubbedApiReact({ initialState, functions })
+const { AragonApi, useAragonApi, useNetwork } = buildStubbedApiReact({ initialState, functions })
 
-export { useAragonApi, useNetwork }
+export { AragonApi, useAragonApi, useNetwork }

--- a/apps/address-book/app/index.js
+++ b/apps/address-book/app/index.js
@@ -10,7 +10,7 @@ import ReactDOM from 'react-dom'
  * }
  */
 
-import { AragonApi } from '@aragon/api-react'
+import { AragonApi } from './api-react'
 import appStateReducer from './app-state-reducer'
 import App from './components/App/App'
 

--- a/apps/allocations/app/api-react.js
+++ b/apps/allocations/app/api-react.js
@@ -59,6 +59,6 @@ const functions = process.env.NODE_ENV !== 'production' && ((appState, setAppSta
   }),
 }))
 
-const { useAragonApi, useNetwork } = buildStubbedApiReact({ initialState, functions })
+const { AragonApi, useAragonApi, useNetwork } = buildStubbedApiReact({ initialState, functions })
 
-export { useAragonApi, useNetwork }
+export { AragonApi, useAragonApi, useNetwork }

--- a/apps/allocations/app/index.js
+++ b/apps/allocations/app/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-unused-modules */
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { AragonApi } from '@aragon/api-react'
+import { AragonApi } from './api-react'
 import appStateReducer from './app-state-reducer'
 import App from './components/App/App'
 

--- a/apps/dot-voting/app/api-react.js
+++ b/apps/dot-voting/app/api-react.js
@@ -44,6 +44,6 @@ const functions = process.env.NODE_ENV !== 'production' && ((appState, setAppSta
   }),
 }))
 
-const { useAragonApi, useNetwork } = buildStubbedApiReact({ initialState, functions })
+const { AragonApi, useAragonApi, useNetwork } = buildStubbedApiReact({ initialState, functions })
 
-export { useAragonApi, useNetwork }
+export { AragonApi, useAragonApi, useNetwork }

--- a/apps/dot-voting/app/index.js
+++ b/apps/dot-voting/app/index.js
@@ -10,7 +10,7 @@ if (process.env.NODE_ENV !== 'production') {
   axe(React, ReactDOM, 1000)
 }
 
-import { AragonApi } from '@aragon/api-react'
+import { AragonApi } from './api-react'
 import appStateReducer from './app-state-reducer'
 import App from './App'
 

--- a/apps/projects/app/api-react.js
+++ b/apps/projects/app/api-react.js
@@ -77,6 +77,6 @@ const functions = process.env.NODE_ENV !== 'production' && ((appState, setAppSta
   }
 }))
 
-const { useAragonApi, useNetwork } = buildStubbedApiReact({ initialState, functions })
+const { AragonApi, useAragonApi, useNetwork } = buildStubbedApiReact({ initialState, functions })
 
-export { useAragonApi, useNetwork }
+export { AragonApi, useAragonApi, useNetwork }

--- a/apps/projects/app/index.js
+++ b/apps/projects/app/index.js
@@ -7,7 +7,7 @@ if (process.env.NODE_ENV !== 'production') {
   axe(React, ReactDOM, 1000)
 }
 
-import { AragonApi } from '@aragon/api-react'
+import { AragonApi } from './api-react'
 import appStateReducer from './app-state-reducer'
 import App from './App'
 

--- a/apps/rewards/app/api-react.js
+++ b/apps/rewards/app/api-react.js
@@ -6,6 +6,6 @@ const initialState = process.env.NODE_ENV !== 'production' && {
 const functions = process.env.NODE_ENV !== 'production' && (() => ({
 }))
 
-const { useAragonApi, useNetwork } = buildStubbedApiReact({ initialState, functions })
+const { AragonApi, useAragonApi, useNetwork } = buildStubbedApiReact({ initialState, functions })
 
-export { useAragonApi, useNetwork }
+export { AragonApi,  useAragonApi, useNetwork }

--- a/apps/rewards/app/index.js
+++ b/apps/rewards/app/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-unused-modules */
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { AragonApi } from '@aragon/api-react'
+import { AragonApi } from './api-react'
 import appStateReducer from './app-state-reducer'
 import App from './components/App/App'
 

--- a/apps/shared/test-helpers/ganache-cli.sh
+++ b/apps/shared/test-helpers/ganache-cli.sh
@@ -38,10 +38,10 @@ start_testrpc() {
 		aragon devchain --reset --port "$testrpc_port" &
 	elif [ "$DEV" = true ]; then
 		aragon devchain --reset --port "$testrpc_port" &
-		lerna run frontend --scope=@tps/apps-* &
+		npm run frontend &
 	elif [ "$NO_CLIENT" = true ]; then
 		aragon devchain --reset --port "$testrpc_port" &
-		lerna run frontend --scope=@tps/apps-* &
+		npm run frontend &
 	fi
 
 	testrpc_pid=$!

--- a/shared/api-react/index.js
+++ b/shared/api-react/index.js
@@ -1,4 +1,5 @@
 import {
+  AragonApi,
   useAragonApi as useProductionApi,
   useNetwork as useProductionNetwork,
 } from '@aragon/api-react'
@@ -22,5 +23,5 @@ export default ({ initialState = {}, functions = (() => {}) }) => {
     }
   }
 
-  return { useAragonApi, useNetwork }
+  return { AragonApi, useAragonApi, useNetwork }
 }


### PR DESCRIPTION
This broke with the incorrect addition of the `npm run frontend` script (https://github.com/AutarkLabs/open-enterprise/pull/1109)