### PR TITLE
Allocations: fix creating new account/budget

### DIFF
--- a/apps/allocations/app/components/Panel/NewBudget.js
+++ b/apps/allocations/app/components/Panel/NewBudget.js
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 
 import { Form, FormField } from '../Form'
 import { isStringEmpty } from '../../utils/helpers'
+import { BigNumber } from 'bignumber.js'
 import { MIN_AMOUNT } from '../../utils/constants'
 
 // TODO:: This should be votingTokens from account?
@@ -25,16 +26,18 @@ class NewBudget extends React.Component {
 
   changeField = e => {
     const { name, value } = e.target
-    this.setState({ [name]: value })
-    this.setState({ [name + 'Error']: isStringEmpty(value) ||
-                    (name === 'amount' && value < MIN_AMOUNT) })
+    this.setState({
+      [name]: value,
+      [name + 'Error']: isStringEmpty(value) ||
+        (name === 'amount' && BigNumber(value).lt(MIN_AMOUNT))
+    })
   }
 
   createBudget = () => {
     const { name, amount } = this.state
 
     this.props.onCreateBudget({
-      name,
+      description: name,
       amount,
     })
     this.setState(INITIAL_STATE)
@@ -71,6 +74,7 @@ class NewBudget extends React.Component {
                 name="amount"
                 type="number"
                 min={MIN_AMOUNT}
+                step={0.1}
                 onChange={this.changeField}
                 wide={true}
                 value={amount}


### PR DESCRIPTION
We're in a halfway state right now. We don't have new contracts yet, but we're starting to get new UI.

This keeps the new UI working with the current contracts.

The comparison of a raw JS Number object with `MIN_AMOUNT`, which is a `BigNumber`, was also failing intermittently.