### PR TITLE
[chore] Disable @tps/ui dependencies installation when running `npm i`

### DIFF
--- a/apps/allocations/package.json
+++ b/apps/allocations/package.json
@@ -35,7 +35,6 @@
     "@aragon/ui": "1.0.0-alpha.19",
     "@babel/polyfill": "^7.2.5",
     "@tps/apps-address-book": "^0.0.1",
-    "@tps/ui": "^0.0.1",
     "bignumber.js": "^7.2.1",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",

--- a/apps/projects/package.json
+++ b/apps/projects/package.json
@@ -35,7 +35,6 @@
     "@aragon/ui": "0.33.0",
     "@babel/polyfill": "^7.2.5",
     "@babel/runtime": "^7.6.0",
-    "@tps/ui": "^0.0.1",
     "apollo-boost": "^0.1.22",
     "axios": "^0.18.0",
     "graphql": "^14.0.2",

--- a/lerna.json
+++ b/lerna.json
@@ -8,6 +8,6 @@
     }
   },
   "hoist": true,
-  "packages": ["apps/*", "apps/shared/*", "kits/*", "shared/*"],
+  "packages": ["apps/*", "apps/shared/*", "kits/*"],
   "version": "independent"
 }


### PR DESCRIPTION
This is a simple PR that:
- Removes nonexistent `@tps/ui` dependency (since this folder is not still being built as an usable package)
- Disables this pseudo-package from `lerna`, since it was spending a precious time installing its dependencies.

In the future, if there is a consensus, we can make this a proper package and be built with `rollup`, `babel` or `parcel` to be re-usable by other aragon apps, even published into npmjs. At this moment is just a path where we put some shared files.