### PR TITLE
[chore] Ignore intermediate package-lock.json files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ codealike.json
 **/cypress/screenshots/
 **/cypress/videos/
 flattened_contracts
+
+# Avoid committing other package-lock.json files
+package-lock.json


### PR DESCRIPTION
This is a simple PR that ignores intermediate generated `package-lock.json` files by adding them to `.gitignore` since we are not committing them currently