### PR TITLE
1166 disable submit buttons metamask

### DIFF
--- a/apps/allocations/app/components/App/App.js
+++ b/apps/allocations/app/components/App/App.js
@@ -15,6 +15,7 @@ const nameSorter = (a, b) => a.data.name.toUpperCase() > b.data.name.toUpperCase
 
 const App = () => {
   const [ panel, setPanel ] = useState(null)
+
   const { api, appState } = useAragonApi()
   const { accounts = [], balances = [], entries = [], payouts = [] } = appState
 
@@ -49,7 +50,7 @@ const App = () => {
   const onNewBudget = () => {
     setPanel({
       content: NewBudget,
-      data: { heading: 'New budget', onCreateBudget }
+      data: { heading: 'New budget', onCreateBudget, connectedAccount }
     })
   }
 
@@ -77,6 +78,8 @@ const App = () => {
       },
     })
   }
+
+  const { connectedAccount } = useAragonApi()
 
   const closePanel = () => {
     setPanel(null)

--- a/apps/allocations/app/components/App/App.js
+++ b/apps/allocations/app/components/App/App.js
@@ -16,7 +16,7 @@ const nameSorter = (a, b) => a.data.name.toUpperCase() > b.data.name.toUpperCase
 const App = () => {
   const [ panel, setPanel ] = useState(null)
 
-  const { api, appState } = useAragonApi()
+  const { api, appState, connectedAccount } = useAragonApi()
   const { accounts = [], balances = [], entries = [], payouts = [] } = appState
 
   const onCreateBudget = ({ description }) => {
@@ -75,11 +75,11 @@ const App = () => {
         entities,
         id,
         onSubmitAllocation,
+        connectedAccount
       },
     })
   }
 
-  const { connectedAccount } = useAragonApi()
 
   const closePanel = () => {
     setPanel(null)

--- a/apps/allocations/app/components/Panel/NewAllocation.js
+++ b/apps/allocations/app/components/Panel/NewAllocation.js
@@ -64,6 +64,7 @@ class NewAllocation extends React.Component {
     balance: PropTypes.string.isRequired,
     id: PropTypes.string.isRequired,
     subHeading: PropTypes.string,
+    connectedAccount: PropTypes.string
   }
 
   state = INITIAL_STATE
@@ -178,6 +179,9 @@ class NewAllocation extends React.Component {
 
   render() {
     const { props, state } = this
+
+    const { connectedAccount } = props
+
     const transferEnabled = state.allocationTypeIndex === 1
     let availableTokens =  this.props.balances.map( balance => balance.symbol)
 
@@ -321,6 +325,7 @@ class NewAllocation extends React.Component {
           onSubmit={this.submitAllocation}
           description={props.description}
           submitText="Submit Allocation"
+          disabled={!connectedAccount}
         >
           {descriptionField}
           {settingsField}

--- a/apps/allocations/app/components/Panel/NewBudget.js
+++ b/apps/allocations/app/components/Panel/NewBudget.js
@@ -19,7 +19,8 @@ const INITIAL_STATE = {
 
 class NewBudget extends React.Component {
   static propTypes = {
-    onCreateBudget: PropTypes.func.isRequired
+    onCreateBudget: PropTypes.func.isRequired,
+    connectedAccount: PropTypes.string
   }
 
   state =  INITIAL_STATE
@@ -45,13 +46,14 @@ class NewBudget extends React.Component {
 
   render() {
 
+    const { connectedAccount } = this.props
     const { name, nameError, amount, amountError, currency } = this.state
 
     return (
       <Form
         onSubmit={this.createBudget}
         submitText="Create budget"
-        disabled={nameError || amountError}
+        disabled={nameError || amountError || !connectedAccount}
       >
         <FormField
           required


### PR DESCRIPTION
This add `connectedAccount` as props of `newBudget` and `newAllocations` panels, and link the `disabled` props of `<Form` so the button is disabled when no users are connected.

See #1166 
![ezgif com-video-to-gif(1)](https://user-images.githubusercontent.com/1237971/65268386-f18bb200-db0e-11e9-9fe7-552679736e90.gif)

