### PR TITLE
Remove `concurrency: 1` option from lerna

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,8 +1,5 @@
 {
   "command": {
-    "run": {
-      "concurrency": 1
-    },
     "bootstrap": {
       "progress": true
     }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "dev": "apps/shared/test-helpers/develop-kit.sh",
     "devchain:reset": "aragon devchain --reset",
     "devchain": "lerna run devchain --stream",
-    "frontend": "lerna run frontend --stream --parallel",
+    "frontend": "lerna run frontend --parallel",
     "frontend:address": "cd apps/address-book && npm run frontend",
     "frontend:allocations": "cd apps/allocations && npm run frontend",
     "frontend:dot": "cd apps/dot-voting && npm run frontend",


### PR DESCRIPTION
This runs everything in parallel by default, which means we can remove our `--parallel` flags.

This results in much faster startup of our `start:dev` process, at the cost of making machines quite slow while it runs and having somewhat more chaotic logs.