### PR TITLE
Address book new entity

### DIFF
--- a/apps/address-book/app/components/Form/Form.js
+++ b/apps/address-book/app/components/Form/Form.js
@@ -2,14 +2,24 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { Button, Text, useTheme } from '@aragon/ui'
 
-const Form = ({ children, onSubmit, submitText, heading, subHeading }) => {
+const Form = ({
+  children,
+  onSubmit,
+  submitText,
+  heading,
+  subHeading,
+  disabled,
+  error
+}) => {
   const theme = useTheme()
 
   return (
     // TODO: Fix the SidePanel 2 lines heading thing
     <React.Fragment>
       {heading && <Text size="xxlarge">{heading}</Text>}
-      {subHeading && <Text color={theme.surfaceContentSecondary}>{subHeading}</Text>}
+      {subHeading && (
+        <Text color={theme.surfaceContentSecondary}>{subHeading}</Text>
+      )}
       <div css="height: 1rem" />
       {children}
       <Button
@@ -17,9 +27,11 @@ const Form = ({ children, onSubmit, submitText, heading, subHeading }) => {
         mode="strong"
         wide
         onClick={onSubmit}
+        disabled={disabled}
       >
         {submitText}
       </Button>
+      {error}
     </React.Fragment>
   )
 }
@@ -30,6 +42,8 @@ Form.propTypes = {
   submitText: PropTypes.string.isRequired,
   heading: PropTypes.string,
   subHeading: PropTypes.string,
+  disabled: PropTypes.bool,
+  error: PropTypes.node
 }
 
 Form.defaultProps = {


### PR DESCRIPTION
This implement a new on-time validation on Address book app!

This is based on PR #1245, so please merge it first to see the change. 

- This adds on-time validation on the NewEntity Panel of the Address book.
- This adds a custom entity type on the same panel.

**Remarks**:

- The exact behaviour wasn't specified, so the system is taking the first error and showing it below the submit button.
- There is tons of logic to DRY up between the two different forms. We might want to integrate something like Final Forms into aragon-ui to abstract and uniform validation logic out of the forms. 

See https://youtu.be/m5qysCQm4Mg for a DEMO

**Edited**:

- We deleted the whole `touched` logic to better match with design decision. 
- Also, it have been rebased against `dev`. 

New demo: https://youtu.be/mKKZsuuzpOo

