### PR TITLE
Dot Voting/stubbedAPI: fix createVote with no args

### DIFF
--- a/apps/dot-voting/app/api-react.js
+++ b/apps/dot-voting/app/api-react.js
@@ -15,7 +15,7 @@ const functions = process.env.NODE_ENV !== 'production' && ((appState, setAppSta
   createVote: ({
     description = 'Define the budget allocation for 2020 ops',
     type = 'allocation'
-  }) => setAppState({
+  } = {}) => setAppState({
     ...appState,
     votes: [
       ...appState.votes,


### PR DESCRIPTION
Calling `window.api.createVote()` broke when the args were put into an
object. This fixes it.