### PR TITLE
Fix creating Allocations/Dot Votes

### DIFF
--- a/apps/allocations/app/components/App/App.js
+++ b/apps/allocations/app/components/App/App.js
@@ -36,7 +36,7 @@ const App = () => {
       payoutId,
       recurring,
       period,
-      balance,
+      String(balance),
       tokenAddress
     ).toPromise()
     closePanel()

--- a/apps/allocations/app/components/Panel/NewAllocation.js
+++ b/apps/allocations/app/components/Panel/NewAllocation.js
@@ -66,7 +66,10 @@ class NewAllocation extends React.Component {
     subHeading: PropTypes.string,
   }
 
-  state = INITIAL_STATE
+  state = {
+    ...INITIAL_STATE,
+    tokenAddress: this.props.balances[0].address,
+  }
 
   // TODO: improve field checking for input errors and sanitize
   changeField = ({ target: { name, value } }) => {


### PR DESCRIPTION
At some point recently we started getting an error when trying to create an allocation:

    Uncaught (in promise) Error: invalid number value (arg="_amount", coderType="uint256", value=1000000000000000000)

The `String(balance)` fixes this issue, but another error hid behind it:

    Uncaught (in promise) Error: invalid address (arg="_token", coderType="address", value=undefined)

The initialization of tokenAddress fixes this problem.

Now creating allocations works again. Hooray!