### PR TITLE
Enhanced Dot Voting radspec

### DIFF
--- a/apps/dot-voting/contracts/DotVoting.sol
+++ b/apps/dot-voting/contracts/DotVoting.sol
@@ -84,12 +84,12 @@ contract DotVoting is ADynamicForwarder, AragonApp {
     *         day `_voteTime >= 172800 ? 's' : ''`
     * @param _token MiniMeToken address that will be used as governance token
     * @param _minQuorum Percentage of voters that must participate in
-    *        a vote for it to succeed (expressed as a 10^18 percentage,
+    *        a dot vote for it to succeed (expressed as a 10^18 percentage,
     *        (eg 10^16 = 1%, 10^18 = 100%)
-    * @param _candidateSupportPct Percentage of cast voting power that must
-    *        support a candidate for it to be counted (expressed as a 10^18
+    * @param _candidateSupportPct Percentage of votes cast that must
+    *        support a voting option for it to be valid (expressed as a 10^18
     *        percentage, (eg 10^16 = 1%, 10^18 = 100%)
-    * @param _voteTime Seconds that a vote will be open for token holders to
+    * @param _voteTime Seconds that a vote will be open for tokenholders to
     *        vote (unless it is impossible for the fate of the vote to change)
     */
     function initialize(
@@ -171,10 +171,12 @@ contract DotVoting is ADynamicForwarder, AragonApp {
     }
 
     /**
-    * @notice Change the app-wide minimum candidate support percentage to `@formatPct(_globalCandidateSupportPct)`%.
-    * @param _globalCandidateSupportPct Percentage of cast voting power that must
-    *        support a candidate for it to be counted (expressed as a 10^18
-    *        percentage, (eg 10^16 = 1%, 10^18 = 100%)
+    * @notice Global parameter change: A dot voting option will require at least
+    *        `@formatPct(_globalCandidateSupportPct)`% of the votes for it to be
+    *        considered valid.
+    * @param _globalCandidateSupportPct Percentage of votes cast that must support
+    *        a voting option for it to be valid (expressed as a 10^18 percentage,
+    *        e.g. 10^16 = 1%, 10^18 = 100%)
     */
     function setglobalCandidateSupportPct(uint256 _globalCandidateSupportPct)
     external auth(ROLE_MODIFY_CANDIDATE_SUPPORT)
@@ -185,10 +187,12 @@ contract DotVoting is ADynamicForwarder, AragonApp {
     }
 
     /**
-    * @notice Change the required support to `@formatPct(_minQuorum)`%.
-    * @param _minQuorum Percentage of voters that must participate in
-    *        a vote for it to succeed (expressed as a 10^18 percentage,
-    *        (eg 10^16 = 1%, 10^18 = 100%)
+    * @notice Global parameter change: A dot vote will require a minimum participation
+    *         from `@formatPct(_minQuorum)`% of the total token supply for the proposal
+    *         to be considered valid.
+    * @param _minQuorum Percentage of voters that must participate in a vote for it 
+    *        to be considered valid (expressed as a 10^18 percentage, e.g. 10^16 = 1%,
+    *        10^18 = 100%)
     */
     function setGlobalQuorum(uint256 _minQuorum)
     external auth(ROLE_MODIFY_QUORUM)
@@ -202,8 +206,8 @@ contract DotVoting is ADynamicForwarder, AragonApp {
 
     /**
     * @dev `addCandidate` allows the `ROLE_ADD_CANDIDATES` to add candidates
-    *         (or options) to the current dot vote.
-    * @notice Add `_description` to dot vote #`_voteId` for the purpose of `_metadata`
+    *      (aka voting options) to an open dot vote.
+    * @notice Add voting option "`_description`" to dot vote #`_voteId` for the purpose of `_metadata`
     * @param _voteId id for vote structure this 'ballot action' is connected to
     * @param _metadata Any additional information about the candidate.
     *        Base implementation does not use this parameter.
@@ -277,8 +281,8 @@ contract DotVoting is ADynamicForwarder, AragonApp {
 
     /**
     * @notice `canExecute` is used to check that the participation has been met
-    *         and the vote has reached it's end before the execute
-    *         function is called.
+    *         and the vote has reached it's end before the execute function is
+    *         called.
     * @param _voteId id for vote structure this 'ballot action' is connected to
     * @return True if the vote is elligible for execution.
     */
@@ -333,8 +337,8 @@ contract DotVoting is ADynamicForwarder, AragonApp {
     }
 
         /**
-    * @notice `getCandidateLength` returns the total number of candidates for
-    *         a given vote.
+    * @notice `getCandidateLength` returns the total number of voting options for
+    *         a given dot vote.
     * @param _voteId The ID of the Vote struct in the `votes` array
     */
     function getCandidateLength(uint256 _voteId) public view isInitialized returns
@@ -345,8 +349,7 @@ contract DotVoting is ADynamicForwarder, AragonApp {
     }
 
     /**
-    * @notice `getVoteMetadata` simply pulls the vote metadata out of a vote
-    *         struct and returns the individual value.
+    * @notice `getVoteMetadata` returns the vote metadata for a given dot vote.
     * @param _voteId The ID of the Vote struct in the `votes` array
     */
     function getVoteMetadata(uint256 _voteId) public view isInitialized returns (string) {
@@ -355,8 +358,7 @@ contract DotVoting is ADynamicForwarder, AragonApp {
     }
 
     /**
-    * @notice `getVoterState` allows a user to get the vote weights for a given
-    *         voter.
+    * @notice `getVoterState` returns the voting power for a given voter.
     * @param _voteId The ID of the Vote struct in the `votes` array.
     * @param _voter The voter whose weights will be returned
     */
@@ -391,7 +393,7 @@ contract DotVoting is ADynamicForwarder, AragonApp {
     *        The seventh array is a second array of identification keys, usually mapping to a second level (optional uint256)
     *        The eigth parameter is used as the identifier for this vote. (uint256)
     *        See ExecutionTarget.sol in the test folder for an example  forwarded function (setSignal)
-    * @param _metadata The metadata or vote information attached to this vote
+    * @param _metadata The metadata or vote information attached to the vote.
     * @return voteId The ID(or index) of this vote in the votes array.
     */
     function _newVote(bytes _executionScript, string _metadata) internal


### PR DESCRIPTION
I cleaned up some of the language for the DotVoting.sol radspec

Notes: 
- We should clean up some comments around line 457-458
- Can we use a conditional operator of sorts for `addCandidate` so it only shows the metadata part if it's not empty? e.g.:

``` Add voting option "`_description`" to dot vote #`_voteId` `_metadata.isEmpty ? '' : '( `_metadata`)' ` ```