### PR TITLE
Projects: fix initialState

### DIFF
--- a/apps/projects/app/store/init.js
+++ b/apps/projects/app/store/init.js
@@ -29,8 +29,8 @@ export const initStore = vaultAddress => {
   )
 }
 
-const initState = (vaultContract) => async (cachedState = INITIAL_STATE) => {
-  let nextState = await initializeTokens(cachedState, vaultContract)
+const initState = (vaultContract) => async (cachedState) => {
+  let nextState = await initializeTokens(cachedState || INITIAL_STATE, vaultContract)
   const github = await app.getCache('github').toPromise()
   if (github && github.token) {
     nextState.github = github


### PR DESCRIPTION
`cachedState` now starts off, on the first run, as `null`. The attempt to set the default param does not work, though, because the value is intentionally set, not missing. So instead of defaulting within the argument signature, we need to set the default at the first place where we update our cache.