### PR TITLE
Projects: clean up updateIssueDetail (and more!)

### DIFF
--- a/apps/projects/app/components/Panel/NewIssueCuration/NewIssueCuration.js
+++ b/apps/projects/app/components/Panel/NewIssueCuration/NewIssueCuration.js
@@ -122,7 +122,7 @@ const onSubmitCuration = ({ closePanel, curateIssues }) => (
     emptyIntArray,
     issueNumbers,
     1
-  )
+  ).toPromise()
 }
 
 // TODO: move entire component to functional component

--- a/apps/projects/app/components/Panel/NewProject/RepoSelector.js
+++ b/apps/projects/app/components/Panel/NewProject/RepoSelector.js
@@ -181,7 +181,7 @@ Repo.propTypes = {
 
 const createProject = ({ closePanel, addRepo }) => ({ project }) => {
   closePanel()
-  addRepo(toHex(project))
+  addRepo(toHex(project)).toPromise()
 }
 
 // TODO: move entire component to functional component
@@ -210,8 +210,7 @@ const ScrollableList = styled.div`
   overflow-y: auto;
   padding-right: 10px;
   margin: 16px 0;
-  // Hack needed to make the scrollable list, since the whole SidePanel is a scrollable container
-  height: calc(100vh - 260px);
+  height: calc(100vh - 260px); /* Hack needed to make the scrollable list, since the whole SidePanel is a scrollable container */
 `
 const RepoInfo = styled.div`
   margin: 20px 0;

--- a/apps/projects/app/store/events.js
+++ b/apps/projects/app/store/events.js
@@ -78,47 +78,53 @@ export const handleEvent = async (state, action, vaultAddress, vaultContract) =>
   }
   case BOUNTY_ADDED: {
     if(!returnValues) return nextState
-    let issueData = await loadIssueData(returnValues)
+    const { repoId, issueNumber } = returnValues
+    let issueData = await loadIssueData({ repoId, issueNumber })
     issueData = determineWorkStatus(issueData)
     nextState = syncIssues(nextState, returnValues, issueData, [])
     return nextState
   }
   case ASSIGNMENT_REQUESTED: {
     if(!returnValues) return nextState
-    let issueData = await loadIssueData(returnValues)
-    issueData = await updateIssueDetail(issueData, action)
+    const { repoId, issueNumber } = returnValues
+    let issueData = await loadIssueData({ repoId, issueNumber })
+    issueData = await updateIssueDetail(issueData)
     issueData = determineWorkStatus(issueData)
     nextState = syncIssues(nextState, returnValues, issueData)
     return nextState
   }
   case ASSIGNMENT_APPROVED: {
     if(!returnValues) return nextState
-    let issueData = await loadIssueData(returnValues)
-    issueData = await updateIssueDetail(issueData, action)
+    const { repoId, issueNumber } = returnValues
+    let issueData = await loadIssueData({ repoId, issueNumber })
+    issueData = await updateIssueDetail(issueData)
     issueData = determineWorkStatus(issueData)
     nextState = syncIssues(nextState, returnValues, issueData)
     return nextState
   }
   case SUBMISSION_REJECTED: {
     if(!returnValues) return nextState
-    let issueData = await loadIssueData(returnValues)
-    issueData = await updateIssueDetail(issueData, action)
+    const { repoId, issueNumber } = returnValues
+    let issueData = await loadIssueData({ repoId, issueNumber })
+    issueData = await updateIssueDetail(issueData)
     issueData = determineWorkStatus(issueData)
     nextState = syncIssues(nextState, returnValues, issueData)
     return nextState
   }
   case WORK_SUBMITTED: {
     if(!returnValues) return nextState
-    let issueData = await loadIssueData(returnValues)
-    issueData = await updateIssueDetail(issueData, action)
+    const { repoId, issueNumber } = returnValues
+    let issueData = await loadIssueData({ repoId, issueNumber })
+    issueData = await updateIssueDetail(issueData)
     issueData = determineWorkStatus(issueData)
     nextState = syncIssues(nextState, returnValues, issueData)
     return nextState
   }
   case SUBMISSION_ACCEPTED: {
     if (!returnValues) return nextState
-    let issueData = await loadIssueData(returnValues)
-    issueData = await updateIssueDetail(issueData, action)
+    const { repoId, issueNumber } = returnValues
+    let issueData = await loadIssueData({ repoId, issueNumber })
+    issueData = await updateIssueDetail(issueData)
     issueData = determineWorkStatus(issueData)
     nextState = syncIssues(nextState, returnValues, issueData)
     return nextState

--- a/apps/projects/app/store/helpers/issues.js
+++ b/apps/projects/app/store/helpers/issues.js
@@ -1,3 +1,4 @@
+import { toHex } from 'web3-utils'
 import { app } from '../app'
 import { ipfsGet } from '../../utils/ipfs-helpers'
 
@@ -118,11 +119,13 @@ const loadSubmissionData = ({ repoId, issueNumber }) => {
   })
 }
 
-export const updateIssueDetail = async (data, response) => {
+export const updateIssueDetail = async data => {
   let returnData = { ...data }
-  const requestsData = await loadRequestsData(response.returnValues)
+  const repoId = toHex(data.repoId)
+  const issueNumber = String(data.number)
+  const requestsData = await loadRequestsData({ repoId, issueNumber })
   returnData.requestsData = requestsData
-  let submissionData = await loadSubmissionData(response.returnValues)
+  let submissionData = await loadSubmissionData({ repoId, issueNumber })
   returnData.workSubmissions = submissionData
   returnData.work = submissionData[submissionData.length - 1]
   return returnData


### PR DESCRIPTION
See commits for full details.

The main event here is cleaning up `updateIssueDetail`, which was receiving the entire `action` object just so it could use `repoId` and `issueNumber`. It turns out it could already get these values from the first argument passed in.

This PR also fixes `addRepo` and `curateIssues`. These changes are needed to get Projects working with the new client.