### PR TITLE
Projects/script: don't update state unnecessarily

### DIFF
--- a/apps/projects/app/store/events.js
+++ b/apps/projects/app/store/events.js
@@ -67,6 +67,7 @@ export const handleEvent = async (state, action, vaultAddress, vaultContract) =>
   }
   case REQUESTED_GITHUB_DISCONNECT: {
     state.github = INITIAL_STATE.github
+    state.repos = [] // repos will be reloaded from loadReposFromQueue on re-sign-in
     return state
   }
   case REPO_ADDED: {

--- a/apps/projects/app/store/init.js
+++ b/apps/projects/app/store/init.js
@@ -9,8 +9,7 @@ export const initStore = (vaultAddress, standardBountiesAddress) => {
   return app.store(
     async (state, action) => {
       try {
-        const nextState = await handleEvent(state, action, vaultAddress, vaultContract)
-        return nextState
+        return await handleEvent(state, action, vaultAddress, vaultContract)
       } catch (err) {
         console.error(
           `[PROJECTS] store error: ${err}


### PR DESCRIPTION
This improves the performance of our app in general, but is crucial now
that we listen to all events from the StandardBounties contract. We want
to ignore all of these events, leaving state unchanged.

We could improve this even further, as shown in the `github` handlers.
We only need to mutate the specific branch of our state tree that
requires updating, and then React's algorithm that calculates whether it
needs to render only gets calculated for the components that make use of
that specific branch. However, this gets us past the bottleneck
introduced by full-state-rewrites-on-every-event-from-StandardBounties
bottleneck, and that's the main improvement we need right now.