### PR TITLE
Implement `forceAddress` in LocalIdentityBadge #1265

### DIFF
--- a/apps/address-book/app/components/App/Entities.js
+++ b/apps/address-book/app/components/App/Entities.js
@@ -46,6 +46,8 @@ const Entities = ({ entities, onRemoveEntity }) => {
           <LocalIdentityBadge
             key={entryAddress}
             entity={entryAddress}
+            shorten={true}
+            forceAddress
           />,
           <Tag
             key={entryAddress}

--- a/apps/address-book/app/components/LocalIdentityBadge/LocalIdentityBadge.js
+++ b/apps/address-book/app/components/LocalIdentityBadge/LocalIdentityBadge.js
@@ -1,17 +1,18 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { useNetwork } from '@aragon/api-react'
 import { IdentityBadge } from '@aragon/ui'
 import { useIdentity } from './IdentityManager'
 import LocalLabelPopoverTitle from './LocalLabelPopoverTitle'
 import LocalLabelPopoverActionLabel from './LocalLabelPopoverActionLabel'
 
-const LocalIdentityBadge = ({ entity, ...props }) => {
+const LocalIdentityBadge = ({ entity, forceAddress, ...props }) => {
   const network = useNetwork()
   const [ label, showLocalIdentityModal ] = useIdentity(entity)
   const handleClick = () => showLocalIdentityModal(entity)
   return (
     <IdentityBadge
-      label={label || ''}
+      label={(!forceAddress && label) || ''}
       entity={entity}
       networkType={network && network.type}
       popoverAction={{
@@ -28,6 +29,7 @@ const LocalIdentityBadge = ({ entity, ...props }) => {
 
 LocalIdentityBadge.propTypes = {
   ...IdentityBadge.propTypes,
+  forceAddress: PropTypes.bool
 }
 
 export default LocalIdentityBadge

--- a/shared/identity/LocalIdentityBadge.js
+++ b/shared/identity/LocalIdentityBadge.js
@@ -36,12 +36,12 @@ function useIdentity(address) {
   return [ name, handleShowLocalIdentityModal ]
 }
 
-const LocalIdentityBadge = ({ entity, ...props }) => {
+const LocalIdentityBadge = ({ entity, forceAddress, ...props }) => {
   const [ label, showLocalIdentityModal ] = useIdentity(entity)
   const handleClick = () => showLocalIdentityModal(entity)
   return (
     <IdentityBadge
-      customLabel={label || ''}
+      customLabel={(!forceAddress && label) || ''}
       entity={entity}
       popoverAction={{
         label: `${label ? 'Edit' : 'Add'} custom label`,
@@ -65,6 +65,7 @@ const LocalIdentityBadge = ({ entity, ...props }) => {
 
 LocalIdentityBadge.propTypes = {
   entity: PropTypes.string.isRequired,
+	forceAddress: PropTypes.bool
 }
 
 const Wrap = styled.div`


### PR DESCRIPTION
Address books `App/Entities.js` now use `forceAddress` property with
<LocalIdentityBadge />.

The implementation have been copied from [Aragon IdentityBadge component](
https://github.com/aragon/aragon/blob/d754535d8487b94a651209464225d8507ae24a67/src/components/IdentityBadge/LocalIdentityBadge.js#L15)

See https://youtu.be/oxeWHqhoSUo for a demo

![image](https://user-images.githubusercontent.com/1237971/65990658-e4ae7d00-e483-11e9-926b-06d81d23b045.png)
![image](https://user-images.githubusercontent.com/1237971/65990669-eb3cf480-e483-11e9-8602-29ab035f8934.png)
