### PR TITLE
Projects: Initialize Jest; stub first test

### DIFF
--- a/apps/projects/.babelrc
+++ b/apps/projects/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    ["@babel/preset-env", { "modules": false, "useBuiltIns": false }]
+    ["@babel/preset-env", { "useBuiltIns": false }]
   ],
   "plugins": [
     ["styled-components", { "displayName": true }],

--- a/apps/projects/.eslintrc.js
+++ b/apps/projects/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
     es6: true,
     node: true,
     commonjs: true,
+    jest: true,
   },
   extends: [
     'eslint:recommended',
@@ -42,7 +43,10 @@ module.exports = {
       {
         unusedExports: true,
         missingExports: true,
-        ignoreExports: [],
+        ignoreExports: [
+          'test/*',
+          '**/*.test.js',
+        ],
       }
     ],
     "no-undef": "error",

--- a/apps/projects/app/store/events.test.js
+++ b/apps/projects/app/store/events.test.js
@@ -1,0 +1,78 @@
+import { handleEvent } from './events'
+
+jest.mock('@aragon/api')
+
+// mock app.call
+// mock ipfsGet
+// mock bountyContract.call
+
+const DEFAULT_TOKENS = [{ 'addr':'0x0000000000000000000000000000000000000000','symbol':'ETH','decimals':'18','balance':'99000000000000000000' }]
+const DEFAULT_BOUNTY_SETTINGS = { '0':[ '100','300','500' ],'1':[ '0x426567696e6e6572000000000000000000000000000000000000000000000000','0x496e7465726d6564696174650000000000000000000000000000000000000000','0x416476616e636564000000000000000000000000000000000000000000000000' ],'2':'100','3':'336','4':'0x0000000000000000000000000000000000000000','5':'0x46bC737df7f1B3a7436F942813498CBE041a6ea4','expMultipliers':[ '100','300','500' ],'expLevels':[ '0x426567696e6e6572000000000000000000000000000000000000000000000000','0x496e7465726d6564696174650000000000000000000000000000000000000000','0x416476616e636564000000000000000000000000000000000000000000000000' ],'baseRate':1,'bountyDeadline':'336','bountyCurrency':'0x0000000000000000000000000000000000000000','bountyAllocator':'0x46bC737df7f1B3a7436F942813498CBE041a6ea4','expLvls':[{ 'mul':1,'name':'Beginner' },{ 'mul':3,'name':'Intermediate' },{ 'mul':5,'name':'Advanced' }] }
+const DEFAULT_GITHUB = { 'status':'initial','token':null,'event':'' }
+
+test('BountyAdded', async () => {
+  const startingState = {
+    'repos':[],
+    'tokens':DEFAULT_TOKENS,
+    'issues':[],
+    'bountySettings': DEFAULT_BOUNTY_SETTINGS,
+    'github': DEFAULT_GITHUB,
+  }
+  const action = {
+    'logIndex':4,
+    'transactionIndex':0,
+    'transactionHash':'0xd14859b881d457e93154f47e9d51c680f7bd357aea51dcba661778f00baaa9d0',
+    'blockHash':'0xda914bf68dffb1eb33796b540d1b510fd88ab53057079465f0c848c421eaf400',
+    'blockNumber':111,
+    'address':'0x5ec5DDf7A0cdD3235AD1bCC0ad04F059507EC5a3',
+    'type':'mined',
+    'id':'log_5f33355a',
+    'returnValues':{ '0':'0x4d4445774f6c4a6c6347397a61585276636e6b784d6a59344f546b784e444d3d',
+      '1':'1234',
+      '2':'1000000000000000000',
+      '3':'0',
+      '4':'QmdnQVVo7rbY8YmKBPMiwktBQtghGabmQbzVFe8UrxyuTB',
+      'repoId':'0x4d4445774f6c4a6c6347397a61585276636e6b784d6a59344f546b784e444d3d',
+      'issueNumber':'1234',
+      'bountySize':'1000000000000000000',
+      'registryId':'0',
+      'ipfsHash':'QmdnQVVo7rbY8YmKBPMiwktBQtghGabmQbzVFe8UrxyuTB' },
+    'event':'BountyAdded',
+    'signature':'0x3b14d766bf8aac539d952be8afbf82762890d5cda3ba03a94b31daac144fc865',
+  }
+  const endingState = {
+    'repos':[],
+    'tokens':DEFAULT_TOKENS,
+    'issues':[{
+      'issueNumber':'1234',
+      'data':{
+        'number':1234,
+        'repoId':'MDEwOlJlcG9zaXRvcnkxMjY4OTkxNDM=',
+        'assignee':'0x0000000000000000000000000000000000000000',
+        'balance':'1000000000000000000',
+        'hasBounty':true,
+        'standardBountyId':'0',
+        'deadline':'2019-10-01T20:49:08.753Z',
+        'token':'0x0000000000000000000000000000000000000000',
+        'workStatus':'funded',
+        'detailsOpen':0,
+        'exp':0,
+        'fundingHistory':[{ 'user':{ 'id':'MDQ6VXNlcjIyMTYxNA==',
+          'login':'chadoh',
+          'url':'https://github.com/chadoh',
+          'avatarUrl':'https://avatars1.githubusercontent.com/u/221614?v=4',
+          '__typename':'User' },
+        'date':'2019-10-01T20:48:59.485Z' }],
+        'hours':1,
+        'key':'MDU6SXNzdWU0OTI0Njc4MDY=',
+        'repo':'open-enterprise',
+        'size':1,
+        'slots':1,
+        'slotsIndex':0
+      }
+    }],
+    'bountySettings': DEFAULT_BOUNTY_SETTINGS,
+    'github': DEFAULT_GITHUB,
+  }
+  expect(await handleEvent(startingState, action)).toEqual(endingState)
+})

--- a/apps/projects/app/utils/github.js
+++ b/apps/projects/app/utils/github.js
@@ -1,3 +1,5 @@
+import '@babel/polyfill'
+
 const STATUS = {
   AUTHENTICATED: 'authenticated',
   FAILED: 'failed',

--- a/apps/projects/jest.config.js
+++ b/apps/projects/jest.config.js
@@ -1,0 +1,187 @@
+// For a detailed explanation regarding each configuration property, visit:
+// https://jestjs.io/docs/en/configuration.html
+
+module.exports = {
+  // All imported modules in your tests should be mocked automatically
+  // automock: false,
+
+  // Stop running tests after `n` failures
+  // bail: 0,
+
+  // Respect "browser" field in package.json when resolving modules
+  // browser: false,
+
+  // The directory where Jest should store its cached dependency information
+  // cacheDirectory: "/private/var/folders/ft/3pfgmys17374js6g63l6v0r80000gn/T/jest_dx",
+
+  // Automatically clear mock calls and instances between every test
+  // clearMocks: false,
+
+  // Indicates whether the coverage information should be collected while executing the test
+  // collectCoverage: false,
+
+  // An array of glob patterns indicating a set of files for which coverage information should be collected
+  // collectCoverageFrom: null,
+
+  // The directory where Jest should output its coverage files
+  // coverageDirectory: null,
+
+  // An array of regexp pattern strings used to skip coverage collection
+  // coveragePathIgnorePatterns: [
+  //   "/node_modules/"
+  // ],
+
+  // A list of reporter names that Jest uses when writing coverage reports
+  // coverageReporters: [
+  //   "json",
+  //   "text",
+  //   "lcov",
+  //   "clover"
+  // ],
+
+  // An object that configures minimum threshold enforcement for coverage results
+  // coverageThreshold: null,
+
+  // A path to a custom dependency extractor
+  // dependencyExtractor: null,
+
+  // Make calling deprecated APIs throw helpful error messages
+  // errorOnDeprecated: false,
+
+  // Force coverage collection from ignored files using an array of glob patterns
+  // forceCoverageMatch: [],
+
+  // A path to a module which exports an async function that is triggered once before all test suites
+  // globalSetup: null,
+
+  // A path to a module which exports an async function that is triggered once after all test suites
+  // globalTeardown: null,
+
+  // A set of global variables that need to be available in all test environments
+  // globals: {},
+
+  // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
+  // maxWorkers: "50%",
+
+  // An array of directory names to be searched recursively up from the requiring module's location
+  // moduleDirectories: [
+  //   "node_modules"
+  // ],
+
+  // An array of file extensions your modules use
+  // moduleFileExtensions: [
+  //   "js",
+  //   "json",
+  //   "jsx",
+  //   "ts",
+  //   "tsx",
+  //   "node"
+  // ],
+
+  // A map from regular expressions to module names that allow to stub out resources with a single module
+  // moduleNameMapper: {},
+
+  // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
+  // modulePathIgnorePatterns: [],
+
+  // Activates notifications for test results
+  // notify: false,
+
+  // An enum that specifies notification mode. Requires { notify: true }
+  // notifyMode: "failure-change",
+
+  // A preset that is used as a base for Jest's configuration
+  // preset: null,
+
+  // Run tests from one or more projects
+  // projects: null,
+
+  // Use this configuration option to add custom reporters to Jest
+  // reporters: undefined,
+
+  // Automatically reset mock state between every test
+  // resetMocks: false,
+
+  // Reset the module registry before running each individual test
+  // resetModules: false,
+
+  // A path to a custom resolver
+  // resolver: null,
+
+  // Automatically restore mock state between every test
+  // restoreMocks: false,
+
+  // The root directory that Jest should scan for tests and modules within
+  // rootDir: null,
+
+  // A list of paths to directories that Jest should use to search for files in
+  // roots: [
+  //   "<rootDir>"
+  // ],
+
+  // Allows you to use a custom runner instead of Jest's default test runner
+  // runner: "jest-runner",
+
+  // The paths to modules that run some code to configure or set up the testing environment before each test
+  // setupFiles: [],
+
+  // A list of paths to modules that run some code to configure or set up the testing framework before each test
+  // setupFilesAfterEnv: [],
+
+  // A list of paths to snapshot serializer modules Jest should use for snapshot testing
+  // snapshotSerializers: [],
+
+  // The test environment that will be used for testing
+  testEnvironment: 'node',
+
+  // Options that will be passed to the testEnvironment
+  // testEnvironmentOptions: {},
+
+  // Adds a location field to test results
+  // testLocationInResults: false,
+
+  // The glob patterns Jest uses to detect test files
+  testMatch: [
+    '**/app/**/?(*.)+(spec|test).[tj]s?(x)',
+  ],
+
+  // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
+  // testPathIgnorePatterns: [
+  //   "/node_modules/"
+  // ],
+
+  // The regexp pattern or array of patterns that Jest uses to detect test files
+  // testRegex: [],
+
+  // This option allows the use of a custom results processor
+  // testResultsProcessor: null,
+
+  // This option allows use of a custom test runner
+  // testRunner: "jasmine2",
+
+  // This option sets the URL for the jsdom environment. It is reflected in properties such as location.href
+  // testURL: "http://localhost",
+
+  // Setting this value to "fake" allows the use of fake timers for functions such as "setTimeout"
+  // timers: "real",
+
+  // A map from regular expressions to paths to transformers
+  // transform: null,
+
+  // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
+  // transformIgnorePatterns: [
+  //   "/node_modules/"
+  // ],
+
+  // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
+  // unmockedModulePathPatterns: undefined,
+
+  // Indicates whether each individual test should be reported during the run
+  // verbose: null,
+
+  // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
+  // watchPathIgnorePatterns: [],
+
+  // Whether to use watchman for file crawling
+  // watchman: true,
+}

--- a/apps/projects/package.json
+++ b/apps/projects/package.json
@@ -27,7 +27,9 @@
     "start": "aragon run",
     "sync-assets": "copy-aragon-ui-assets -n aragon-ui ./dist && npm run copy-public-assets",
     "test:gas": "GAS_REPORTER=true npm test",
-    "test": "TRUFFLE_TEST=true npm run ganache-cli:test"
+    "test": "TRUFFLE_TEST=true npm run ganache-cli:test",
+    "test:app": "jest",
+    "test:app:watch": "jest --watch"
   },
   "dependencies": {
     "@aragon/api": "AutarkLabs/aragon-api",
@@ -38,6 +40,7 @@
     "@babel/runtime": "^7.6.0",
     "apollo-boost": "^0.1.22",
     "axios": "^0.18.0",
+    "date-fns": "2.0.0-alpha.22",
     "graphql": "^14.0.2",
     "graphql-request": "^1.8.2",
     "graphql-tag": "^2.10.0",
@@ -49,8 +52,7 @@
     "react-markdown": "^4.1.0",
     "react-number-format": "^4.0.8",
     "styled-components": "4.1.3",
-    "web3-utils": "^1.0.0",
-    "date-fns": "2.0.0-alpha.22"
+    "web3-utils": "^1.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",
@@ -60,6 +62,7 @@
     "@babel/preset-react": "^7.0.0",
     "@tps/test-helpers": "^0.0.1",
     "babel-eslint": "^10.0.1",
+    "babel-jest": "^24.9.0",
     "babel-plugin-styled-components": "^1.10.0",
     "eslint": "^5.16.0",
     "eslint-config-prettier": "^6.0.0",
@@ -71,6 +74,7 @@
     "eslint-plugin-promise": "^4.1.1",
     "eslint-plugin-react": "^7.13.0",
     "eslint-plugin-standard": "^4.0.0",
+    "jest": "^24.9.0",
     "lint-staged": "^9.2.0",
     "parcel-bundler": "1.12.3",
     "prettier-eslint": "^9.0.0",


### PR DESCRIPTION
Initial stab at adding testing to our reducer. Got held up on mocking calls to our contracts.

To use:

* `cd apps/projects`
* `npm run test:app` or `npm run test:app:watch`

This changes our `.babelrc` and removes `modules: false`. Jest requires that we avoid this setting. `npm run build:app` still works, which means this setting may have been here for no reason.