### PR TITLE
PlanningKit.sol: update hard-coded StandardBounties address

### DIFF
--- a/apps/planning-suite-kit/contracts/PlanningKit.sol
+++ b/apps/planning-suite-kit/contracts/PlanningKit.sol
@@ -83,7 +83,7 @@ contract PlanningKit is KitBase {
         // Generate Tokens
         token.generateTokens(address(root), 200 ether); // give root 100 autark tokens
         token.generateTokens(address(this), 100 ether); // give root 100 autark tokens
-        registry = 0x46bC737df7f1B3a7436F942813498CBE041a6ea4; // hardcoded from the publish:http logs TODO: make dynamic
+        registry = 0x2e25c8F88c5cCcbC9400e5bc86cF9C58C7604327; // hardcoded from the publish:http logs TODO: make dynamic
     }
 
     function newInstance() public {


### PR DESCRIPTION
This address changes depending on the content of our contracts and the order in which they are deployed. This is accurate for running `npm run publish:http` right now.

Until we get the new template in, which supports making this value a variable, we will need to keep making PRs like this when new contracts get merged.