### PR TITLE
Projects: fix focus events in FundIssues

### DIFF
--- a/apps/projects/app/components/Content/Settings.js
+++ b/apps/projects/app/components/Content/Settings.js
@@ -262,7 +262,7 @@ FundingType.propTypes = {
 const Settings = ({ onLogin }) => {
   const [ bountyCurrencies, setBountyCurrencies ] = useState([])
   const [ expLevels, setExpLevels ] = useState([])
-  const [ baseRate, setBaseRate ] = useState()
+  const [ baseRate, setBaseRate ] = useState(0)
   const [ bountyCurrency, setBountyCurrency ] = useState()
   const [ bountyAllocator, setBountyAllocator ] = useState()
   //const [ bountyArbiter, setBountyArbiter ] = useState()


### PR DESCRIPTION
The problem: Every time you type a character in a field in this FundIssues panel, focus on the input is removed, and you have to click back into it to keep typing.

The cause: when you call `setDescription` (or similar), the state changes and the component rerenders. Since `FundForm` is defined within the parent component, this means it gets redefined, and re-rendered to the DOM in its initial state.

The solution: move the definition of `FundForm` outside of the `FundIssues` component.

Taking it further: there's probably extra cleanup we could do here, where state is now defined and managed from FundIssues just so it can be passed through as a prop to FundForm. This could be removed from FundIssues and managed directly within FundForm. For the sake of moving quickly, I did not do this cleanup now.