### PR TITLE
Projects: fix empty-state fonts

### DIFF
--- a/apps/projects/app/App.js
+++ b/apps/projects/app/App.js
@@ -132,9 +132,17 @@ const App = () => {
       </EmptyWrapper>
     )
   } else if (github.status === STATUS.INITIAL) {
-    return <Unauthorized onLogin={handleGithubSignIn} />
+    return (
+      <Main>
+        <Unauthorized onLogin={handleGithubSignIn} />
+      </Main>
+    )
   } else if (github.status === STATUS.FAILED) {
-    return <Error action={noop} />
+    return (
+      <Main>
+        <Error action={noop} />
+      </Main>
+    )
   }
 
   // Tabs are not fixed


### PR DESCRIPTION
In order for aragonUI to load in correct fonts, the content must be wrapped in the `<Main>` component.

## Before

![fonts looking bad](https://user-images.githubusercontent.com/221614/66148643-5fd87600-e5df-11e9-8915-ba11af6adf96.png)

## After

![fonts looking good](https://user-images.githubusercontent.com/221614/66148598-48998880-e5df-11e9-8003-340665b3cf86.png)
