### PR TITLE
Projects: use red/green buttons for review panels

### DIFF
--- a/apps/projects/app/components/Panel/ReviewApplication/ReviewApplication.js
+++ b/apps/projects/app/components/Panel/ReviewApplication/ReviewApplication.js
@@ -202,13 +202,13 @@ class ReviewApplication extends React.Component {
 
             <ReviewRow>
               <ReviewButton
-                emphasis="negative"
+                mode="negative"
                 onClick={this.onReject}
               >
             Reject
               </ReviewButton>
               <ReviewButton
-                emphasis="positive"
+                mode="positive"
                 onClick={this.onAccept}
               >
             Accept

--- a/apps/projects/app/components/Panel/ReviewWork/ReviewWork.js
+++ b/apps/projects/app/components/Panel/ReviewWork/ReviewWork.js
@@ -217,16 +217,14 @@ class ReviewWork extends React.Component {
             <ReviewRow>
               <ReviewButton
                 disabled={this.canSubmit()}
-                emphasis="negative"
-                mode={this.canSubmit() ? 'secondary' : 'strong'}
+                mode="negative"
                 onClick={this.onReject}
               >
             Reject
               </ReviewButton>
               <ReviewButton
                 disabled={this.canSubmit()}
-                emphasis="positive"
-                mode={this.canSubmit() ? 'secondary' : 'strong'}
+                mode="positive"
                 onClick={this.onAccept}
               >
             Accept


### PR DESCRIPTION
New aragonUI uses the `mode` property instead of `emphasis`.

We also don't need to set anything to `secondary`/`normal`, because the buttons are already disabled when the user cannot submit the form.

## old

![paste](https://user-images.githubusercontent.com/221614/66150339-f0648580-e5e2-11e9-964b-9ce1d1f26569.png)

## new

![image](https://user-images.githubusercontent.com/221614/66150358-fb1f1a80-e5e2-11e9-8c2a-dd99dddb3da3.png)
