### PR TITLE
Dot Voting: display label as text when not address

### DIFF
--- a/apps/dot-voting/app/components/VotingOption.js
+++ b/apps/dot-voting/app/components/VotingOption.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Tag, Text } from '@aragon/ui'
+import { GU, Tag, Text } from '@aragon/ui'
 import { animated } from 'react-spring'
 import PropTypes from 'prop-types'
 import { isAddress } from 'web3-utils'
@@ -23,7 +23,14 @@ const Label = ({ fontSize, label }) => {
   }
 
   return (
-    <Text size={fontSize}>
+    <Text
+      size={fontSize}
+      css={fontSize === 'xsmall' && `
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      `}
+    >
       {label}
     </Text>
   )
@@ -39,10 +46,18 @@ const VotingOption = ({ valueSpring, label, percentage, color, threshold, userVo
     <Main>
       <Labels>
         {label && (
-          <div>
+          <div
+            css={`
+              align-items: center;
+              display: grid;
+              grid-gap: ${0.5 * GU}px;
+              grid-template-columns: 1fr auto;
+              margin-right: ${0.5 * GU}px;
+            `}
+          >
             <Label fontSize={fontSize} label={label} />
             {userVote !== -1 && (
-              <Tag label={`YOU: ${userVote}%`} />
+              <Tag css={`margin-top: -${0.25 * GU}px`} label={`YOU: ${userVote}%`} />
             )}
           </div>
         )}

--- a/apps/dot-voting/app/components/VotingOption.js
+++ b/apps/dot-voting/app/components/VotingOption.js
@@ -3,24 +3,44 @@ import styled from 'styled-components'
 import { Tag, Text } from '@aragon/ui'
 import { animated } from 'react-spring'
 import PropTypes from 'prop-types'
+import { isAddress } from 'web3-utils'
 import { useNetwork } from '../api-react'
 import { LocalIdentityBadge } from '../../../../shared/identity'
 
-const VotingOption = ({ valueSpring, label, percentage, color, threshold, userVote, fontSize }) => {
+const Label = ({ fontSize, label }) => {
   const network = useNetwork()
 
+  if (isAddress(label)) {
+    return (
+      <LocalIdentityBadge
+        compact
+        fontSize={fontSize}
+        networkType={network.type}
+        entity={label}
+        shorten
+      />
+    )
+  }
+
+  return (
+    <Text size={fontSize}>
+      {label}
+    </Text>
+  )
+}
+
+Label.propTypes = {
+  fontSize: PropTypes.oneOf([ 'xsmall', 'small' ]),
+  label: PropTypes.string.isRequired,
+}
+
+const VotingOption = ({ valueSpring, label, percentage, color, threshold, userVote, fontSize }) => {
   return (
     <Main>
       <Labels>
         {label && (
           <div>
-            <LocalIdentityBadge
-              compact
-              fontSize={fontSize}
-              networkType={network.type}
-              entity={label}
-              shorten
-            />
+            <Label fontSize={fontSize} label={label} />
             {userVote !== -1 && (
               <Tag label={`YOU: ${userVote}%`} />
             )}


### PR DESCRIPTION
For Dot Votes created from Projects, the options will be regular text.  This displays them as such, while leaving options from Allocations displayed as identity badges.

This also fixes an issue where long issue titles would take up multiple lines in VoteCard, breaking the layout.

## Before

### without any of these changes

![image](https://user-images.githubusercontent.com/221614/66164766-637cf480-e601-11e9-89cb-859e0bd58c90.png)


### after first commit here

![image](https://user-images.githubusercontent.com/221614/66164705-3fb9ae80-e601-11e9-9b2b-d84aafbbd836.png)


## After

### list

![text constrained neatly to one line](https://user-images.githubusercontent.com/221614/66164250-3d0a8980-e600-11e9-9269-b96c63320460.png)

### detail

![image](https://user-images.githubusercontent.com/221614/66164826-814a5980-e601-11e9-9491-70fab2411904.png)
