### PR TITLE
Allocations: fix permission description

### DIFF
--- a/apps/allocations/arapp.json
+++ b/apps/allocations/arapp.json
@@ -1,7 +1,7 @@
 {
   "roles": [
     {
-      "name": "Create allocations account",
+      "name": "Create budget account",
       "id": "CREATE_ACCOUNT_ROLE",
       "params": []
     },


### PR DESCRIPTION
Note from Javi: "Permission descriptions are outdated, it’s Budget account, not allocations account"

This uses the new phrase.