### PR TITLE
Allocations: fix editing budget account

### DIFF
--- a/apps/allocations/app/components/App/App.js
+++ b/apps/allocations/app/components/App/App.js
@@ -14,17 +14,21 @@ const App = () => {
   const [ isModalVisible, setModalVisible ] = useState(false)
   const [ currentBudgetId, setCurrentBudgetId ] = useState('')
   const { api, appState } = useAragonApi()
-  const { allocations = [], budgets = [], tokens = [] } = appState
+  const { allocations = [], budgets = [] } = appState
 
-  const onCreateBudget = ({ amount, name, token }) => {
-    api
-      .newAccount(
-        name,             // _metadata
-        token.address,    // _token
-        true,             // hasBudget
-        amount
-      )
-      .toPromise()
+  const saveBudget = ({ id, amount, name, token }) => {
+    if (id) {
+      api.setBudget(id, amount, name).toPromise()
+    } else {
+      api
+        .newAccount(
+          name,             // _metadata
+          token.address,    // _token
+          true,             // hasBudget
+          amount
+        )
+        .toPromise()
+    }
     closePanel()
   }
 
@@ -68,7 +72,7 @@ const App = () => {
     const fundsLimit = '300000' // remove this!
     setPanel({
       content: NewBudget,
-      data: { heading: 'New budget', onCreateBudget, fundsLimit, tokens },
+      data: { heading: 'New budget', saveBudget, fundsLimit },
     })
   }
 
@@ -88,12 +92,12 @@ const App = () => {
 
   const onEdit = id => {
     const fundsLimit = '300000' // remove this!
-    const editingBudget = budgets.find(budget => budget.budgetId === id)
+    const editingBudget = budgets.find(budget => budget.id === id)
     setPanel({
       content: NewBudget,
       data: {
         heading: 'Edit budget',
-        onCreateBudget,
+        saveBudget,
         editingBudget,
         fundsLimit,
       },

--- a/apps/allocations/app/components/Panel/NewBudget.js
+++ b/apps/allocations/app/components/Panel/NewBudget.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
+import { useAragonApi } from '../../api-react'
 import { DropDown, IconClose, Info, TextInput, theme } from '@aragon/ui'
 import styled from 'styled-components'
 
@@ -21,22 +22,26 @@ const INITIAL_STATE = {
 
 class NewBudget extends React.Component {
   static propTypes = {
-    onCreateBudget: PropTypes.func.isRequired,
+    saveBudget: PropTypes.func.isRequired,
     editingBudget: PropTypes.object,
     fundsLimit: PropTypes.string.isRequired,
     tokens: PropTypes.array
   }
 
+  static defaultProps = {
+    editingBudget: {},
+  }
+
   constructor(props) {
     super(props)
     this.state =  INITIAL_STATE
-    if (props.editingBudget) {
+    if (props.editingBudget.id) {
       this.state.name = props.editingBudget.name
       this.state.nameError = false
       this.state.amount = BigNumber(props.editingBudget.amount)
         .div(ETH_DECIMALS)
       this.state.amountError = false
-      this.state.selectedToken = props.editingBudget.token === 'ETH' ? 0 : 1 // change this!!
+      this.state.selectedToken = props.editingBudget.token.symbol === 'ETH' ? 0 : 1
       this.state.buttonText = 'Submit'
     }
   }
@@ -61,7 +66,7 @@ class NewBudget extends React.Component {
     const { name, amount, selectedToken } = this.state
     const token = this.props.tokens[selectedToken]
     const amountWithDecimals = BigNumber(amount).times(BigNumber(10).pow(token.decimals)).toString()
-    this.props.onCreateBudget({ name, amount: amountWithDecimals, token })
+    this.props.saveBudget({ id: this.props.editingBudget.id, name, amount: amountWithDecimals, token })
     this.setState(INITIAL_STATE)
   }
 
@@ -102,7 +107,7 @@ class NewBudget extends React.Component {
                 Amount must be smaller than underlying funds
               </ErrorText>
             )}
-            { this.props.editingBudget && (
+            { this.props.editingBudget.id && (
               <Info>
                 Please keep in mind that any changes to the budget amount may only be effectuated upon the starting date of the next accounting period.
               </Info>
@@ -153,6 +158,11 @@ class NewBudget extends React.Component {
   }
 }
 
+const NewBudgetWrap = props => {
+  const { appState: { tokens = [] } } = useAragonApi()
+  return <NewBudget tokens={tokens} {...props} />
+}
+
 const InputGroup = styled.div`
   display: flex;
 `
@@ -167,4 +177,4 @@ const ErrorText = styled.div`
 const ErrorContainer = styled.div``
 
 // eslint-disable-next-line import/no-unused-modules
-export default NewBudget
+export default NewBudgetWrap

--- a/apps/allocations/app/store/events.js
+++ b/apps/allocations/app/store/events.js
@@ -23,10 +23,11 @@ const eventHandler = async eventData => {
 
     return vaultLoadBalance(state, returnValues, settings)
   }
- 
+
   // Allocations events
   switch (event) {
   case 'NewAccount':
+  case 'SetBudget':
     return {
       ...state,
       accounts: await updateAccounts(state.accounts, returnValues.accountId),


### PR DESCRIPTION
* Stop passing `tokens`; calculate it in NewBudget
* Fix finding `editingBudget`
* Rename `onCreateBudget` to `saveBudget`, make it deal with updating as well as creating
* Listen for `SetBudget` event in Allocations background reducer