### PR TITLE
Fine tune template permissions

### DIFF
--- a/templates/open-enterprise/contracts/BaseCache.sol
+++ b/templates/open-enterprise/contracts/BaseCache.sol
@@ -10,6 +10,7 @@ contract BaseCache is BaseTemplate {
         ACL acl;
         Kernel dao;
         Finance finance;
+        TokenManager tokenManager;
         Vault vault;
         Voting voting;
     }
@@ -28,6 +29,7 @@ contract BaseCache is BaseTemplate {
         ACL _acl,
         Kernel _dao,
         Finance _finance,
+        TokenManager _tokenManager,
         Vault _vault,
         Voting _voting,
         address _owner
@@ -37,22 +39,23 @@ contract BaseCache is BaseTemplate {
         baseInstance.acl = _acl;
         baseInstance.dao = _dao;
         baseInstance.finance = _finance;
+        baseInstance.tokenManager = _tokenManager;
         baseInstance.vault = _vault;
         baseInstance.voting = _voting;
     }
 
-    function _popBaseCache(address _owner) internal returns (ACL, Kernel, Finance, Vault, Voting) {
+    function _popBaseCache(address _owner) internal returns (ACL, Kernel, Finance, TokenManager, Vault, Voting) {
         // require(baseCache[_owner] != address(0), ERROR_MISSING_BASE_CACHE);
-        // TODO: need to return tokenManger, but I don't know
 
-        InstalledBase baseInstance = baseCache[_owner];
+        InstalledBase storage baseInstance = baseCache[_owner];
         ACL acl = baseInstance.acl;
         Kernel dao = baseInstance.dao;
         Finance finance = baseInstance.finance;
+        TokenManager tokenManager = baseInstance.tokenManager;
         Vault vault = baseInstance.vault;
         Voting voting = baseInstance.voting;
 
         delete baseCache[_owner];
-        return (acl, dao, finance, vault, voting);
+        return (acl, dao, finance, tokenManager, vault, voting);
     }
 }

--- a/templates/open-enterprise/contracts/BaseOEApps.sol
+++ b/templates/open-enterprise/contracts/BaseOEApps.sol
@@ -182,4 +182,12 @@ contract BaseOEApps is BaseCache, TokenCache {
         _acl.grantPermission(_projects, _vault, _vault.TRANSFER_ROLE());
         _acl.grantPermission(_rewards, _vault, _vault.TRANSFER_ROLE());
     }
+
+    /**
+     * @dev Overloading from BaseTemplate to remove the grant, that is not needed for Open Enterprise
+     */
+    function _transferPermissionFromTemplate(ACL _acl, address _app, bytes32 _permission, address _manager) internal {
+        _acl.revokePermission(address(this), _app, _permission);
+        _acl.setPermissionManager(_manager, _app, _permission);
+    }
 }

--- a/templates/open-enterprise/contracts/OpenEnterpriseTemplate.sol
+++ b/templates/open-enterprise/contracts/OpenEnterpriseTemplate.sol
@@ -75,7 +75,7 @@ contract OpenEnterpriseTemplate is BaseOEApps {
         //TODO: need to be able to pass a token manager into _setupOEApps to set proper permissions for dot voting
         _setupOEApps(dao, acl, tokenManager, vault, voting, _dotVotingSettings, _allocationsPeriod, _useDiscussions);
         _transferCreatePaymentManagerFromTemplate(acl, finance, voting);
-        _transferPermissionFromTemplate(acl, vault, voting, vault.TRANSFER_ROLE(), voting);
+        _transferPermissionFromTemplate(acl, vault, vault.TRANSFER_ROLE(), voting);
         _transferRootPermissionsFromTemplateAndFinalizeDAO(dao, voting);
     }
 


### PR DESCRIPTION
- Setup Voting as grantee for voting settings permissions (it was ANY_ACCOUNT previously)
- Remove grant from `_transferPermissionFromTemplate` by overloading the function
- Add TokenManager to the cached contract, that allows to:
- Setup TokenManager as grantee for DotVoting and Voting apps
