### PR TITLE
Allocations/Autocomplete: fix visual & code styles

### DIFF
--- a/shared/ui/components/form/inputs/LocalIdentitiesAutoComplete.js
+++ b/shared/ui/components/form/inputs/LocalIdentitiesAutoComplete.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { useAragonApi } from '@aragon/api-react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
@@ -14,16 +14,16 @@ import {
 const withKey = item => ({ key: item.address, ...item })
 const sortAlphAsc = (a, b) => a.name.localeCompare(b.name)
 
-const LocalIdentitiesAutoComplete = React.memo(
-  React.forwardRef(function LocalIdentitiesAutoComplete(
+const LocalIdentitiesAutoComplete = React.forwardRef(
+  function LocalIdentitiesAutoComplete(
     { onChange, wide, value, required },
     ref
   ) {
     const { api } = useAragonApi()
     const theme = useTheme()
-    const [items, setItems] = useState([])
-    const [selected, setSelected] = useState(null)
-    const [searchTerm, setSearchTerm] = useState('')
+    const [ items, setItems ] = useState([])
+    const [ selected, setSelected ] = useState(null)
+    const [ searchTerm, setSearchTerm ] = useState('')
 
     const handleSearch = useCallback(
       async term => {
@@ -111,7 +111,7 @@ const LocalIdentitiesAutoComplete = React.memo(
         }
       }
       effect()
-    }, [selected, value, api])
+    }, [ selected, value, api ])
 
     return (
       <AutoCompleteSelected
@@ -135,6 +135,7 @@ const LocalIdentitiesAutoComplete = React.memo(
         required={required}
         selected={selected}
         selectedButtonStyles={`
+          display: block;
           padding: 0;
 
           &:focus,
@@ -147,8 +148,9 @@ const LocalIdentitiesAutoComplete = React.memo(
         wide={wide}
       />
     )
-  })
+  }
 )
+
 
 LocalIdentitiesAutoComplete.propTypes = {
   onChange: PropTypes.func.isRequired,

--- a/shared/ui/components/form/inputs/RecipientsInput.js
+++ b/shared/ui/components/form/inputs/RecipientsInput.js
@@ -1,8 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
-import { Button, IconRemove, TextInput, theme, unselectable } from '@aragon/ui'
-import web3Utils from 'web3-utils'
+import { Button, IconRemove, theme, unselectable } from '@aragon/ui'
 
 import LocalIdentitiesAutoComplete from './LocalIdentitiesAutoComplete'
 
@@ -10,7 +9,6 @@ const RecipientsInput = ({
   recipients,
   recipientsValid,
   onChange,
-  placeholder = '',
 }) => {
 
   const changeRecipient = (value, id) => {
@@ -56,8 +54,9 @@ const RecipientsInput = ({
                   style={{ transform: 'scale(.8)' }}
                   onClick={() => removeRecipient(id)}
                   title="Remove this recipient"
-                  children={<IconRemove />}
-                />
+                >
+                  <IconRemove />
+                </IconContainer>
               )}
             </StyledRecipient>
           ))}
@@ -66,9 +65,10 @@ const RecipientsInput = ({
         compact
         mode="secondary"
         onClick={addRecipient}
-        children={'+ Add Another'}
         title={'Click to add'}
-      />
+      >
+        + Add Another
+      </StyledButton>
     </div>
   )
 }
@@ -82,7 +82,6 @@ RecipientsInput.propTypes = {
   recipients: PropTypes.object.isRequired,
   recipientsValid: PropTypes.object.isRequired,
   onChange: PropTypes.func.isRequired,
-  placeholder: PropTypes.string,
 }
 
 const flexColumn = { display: 'flex', flexDirection: 'column' }
@@ -96,7 +95,6 @@ const StyledRecipient = styled.div`
 `
 
 const AutoCompleteWrapper = styled.div`
-  border: ${({ valid }) => valid ? `2px solid ${theme.positive}` : 'none' };
   border-radius: 6px;
 `
 


### PR DESCRIPTION
* Remove thick green border on selected item
* Remove extra padding below selected item (believe it or not, that's what the `display: block` is for)
* Fix code style issues identified by linter