### PR TITLE
Allocations/New: show "Available in Vault"

### DIFF
--- a/apps/allocations/app/components/Panel/NewAllocation.js
+++ b/apps/allocations/app/components/Panel/NewAllocation.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import { DropDown, IconClose, Text, TextInput, theme } from '@aragon/ui'
+import { DropDown, GU, IconClose, Text, TextInput, font, theme } from '@aragon/ui'
 import web3Utils from 'web3-utils'
 import styled from 'styled-components'
 import { BigNumber } from 'bignumber.js'
@@ -147,7 +147,7 @@ class NewAllocation extends React.Component {
   }
 
   render() {
-    const { budgets } = this.props
+    const { balances, budgets } = this.props
     const {
       budgetValue,
       descriptionValue,
@@ -162,6 +162,9 @@ class NewAllocation extends React.Component {
       recipientsDuplicate,
       tokenValue,
     } = this.state
+
+    const remainingBudget = displayCurrency(BigNumber(budgetValue.remaining))
+    const inVault = displayCurrency(balances.find(b => b.address === tokenValue.address).amount)
 
     const budgetDropDown = (
       <FormField
@@ -201,8 +204,20 @@ class NewAllocation extends React.Component {
         required
         label="Amount"
         input={
-          <React.Fragment>
-            <InputGroup>
+          <div css={`
+            display: flex;
+            flex-direction: column-reverse;
+            align-items: flex-end;
+            color: ${theme.textSecondary};
+            ${font({ size: 'small' })}
+          `}>
+            <Text>
+              Available in Vault: {inVault} {tokenValue.symbol}
+            </Text>
+            <Text>
+              Available Budget: {remainingBudget} {tokenValue.symbol}
+            </Text>
+            <InputGroup css={`margin-bottom: ${GU}px; width: 100%`}>
               <TextInput
                 name="amount"
                 type="number"
@@ -215,17 +230,7 @@ class NewAllocation extends React.Component {
               />
               <CurrencyBox>{tokenValue.symbol}</CurrencyBox>
             </InputGroup>
-            <InputGroup css={{ justifyContent: 'flex-end' }}>
-              <Text
-                size="small"
-                css={{ paddingTop: '10px', color: theme.contentSecondary }}>
-                {'Available Budget: '}
-                {displayCurrency(BigNumber(budgetValue.remaining))}
-                {' '}
-                {tokenValue.symbol}
-              </Text>
-            </InputGroup>
-          </React.Fragment>
+          </div>
         }
       />
     )


### PR DESCRIPTION
* Simplify markup
* Place text in order that makes most sense for screenreaders; use `flex-direction: column-reverse` for sensible visual design

![Available Budget: 111 ETH; Available in Vault: 200 ETH](https://user-images.githubusercontent.com/221614/66666943-d13ba880-ec1f-11e9-8114-3f6def8a842a.png)