### PR TITLE
Allocations: remove red styling from Amounts

### DIFF
--- a/apps/allocations/app/components/App/AllocationsHistory.js
+++ b/apps/allocations/app/components/App/AllocationsHistory.js
@@ -58,7 +58,7 @@ const AllocationsHistory = ({ allocations }) => {
             : recipients.length + ' entities',
           description,
           <Status key={index} code={status} />,
-          <Amount key={index} theme={theme} >
+          <Amount key={index}>
             { displayCurrency(BigNumber(amount)) } { getTokenSymbol(token) }
           </Amount>
         ]
@@ -113,7 +113,6 @@ Status.propTypes = {
 }
 
 const Amount = styled.div`
-  color: ${({ theme }) => theme.negative};
   font-weight: 600;
 `
 


### PR DESCRIPTION
Since every amount in this column will always be a debit, we've decided it does not help the user understand anything to shout at them with this bold color.

![Amount: 11 ETH](https://user-images.githubusercontent.com/221614/66668288-dfd78f00-ec22-11e9-9db3-4c1dbd64b736.png)
