### PR TITLE
allow budget and allocation inputs to handle large values (gt 10e21)

### DIFF
--- a/apps/allocations/app/components/App/App.js
+++ b/apps/allocations/app/components/App/App.js
@@ -52,7 +52,7 @@ const App = () => {
       '1', // recurrences, 1 for now
       Math.floor(new Date().getTime()/1000), // startTime, now for now
       period,
-      String(balance), // amount
+      balance, // amount
     ).toPromise()
     closePanel()
 

--- a/apps/allocations/app/components/Panel/NewAllocation.js
+++ b/apps/allocations/app/components/Panel/NewAllocation.js
@@ -133,12 +133,13 @@ class NewAllocation extends React.Component {
       budgetValue,
       descriptionValue,
       amountValue,
-      recipients
+      recipients,
+      tokenValue
     } = this.state
     const allocation = {
       budgetId: this.props.budgetId,
       budgetName: budgetValue,
-      balance: amountValue * 10e17,
+      balance: BigNumber(amountValue).times(BigNumber(10).pow(tokenValue.decimals)).toString(10),
       description: descriptionValue,
       addresses: Object.values(recipients),
     }

--- a/apps/allocations/app/components/Panel/NewBudget.js
+++ b/apps/allocations/app/components/Panel/NewBudget.js
@@ -65,7 +65,7 @@ class NewBudget extends React.Component {
   createBudget = () => {
     const { name, amount, selectedToken } = this.state
     const token = this.props.tokens[selectedToken]
-    const amountWithDecimals = BigNumber(amount).times(BigNumber(10).pow(token.decimals)).toString()
+    const amountWithDecimals = BigNumber(amount).times(BigNumber(10).pow(token.decimals)).toString(10)
     this.props.saveBudget({ id: this.props.editingBudget.id, name, amount: amountWithDecimals, token })
     this.setState(INITIAL_STATE)
   }


### PR DESCRIPTION
These changes allow users to create allocations for token amounts where the raw value can be bigger than 10e21, before token decimal division