### PR TITLE
allow address book to initialize on installation

### DIFF
--- a/templates/open-enterprise/contracts/BaseOEApps.sol
+++ b/templates/open-enterprise/contracts/BaseOEApps.sol
@@ -54,7 +54,8 @@ contract BaseOEApps is BaseCache, TokenCache {
     /* ADDRESS-BOOK */
 
     function _installAddressBookApp(Kernel _dao) internal returns (AddressBook) {
-        return AddressBook(_installNonDefaultApp(_dao, ADDRESS_BOOK_APP_ID));
+        bytes memory initializeData = abi.encodeWithSelector(AddressBook(0).initialize.selector);
+        return AddressBook(_installNonDefaultApp(_dao, ADDRESS_BOOK_APP_ID, initializeData));
     }
 
     function _createAddressBookPermissions(ACL _acl, AddressBook _addressBook, address _grantee, address _manager) internal {


### PR DESCRIPTION
We found that passing in `bytes(0)` for the initializiation payload forces the [AppProxyBase to skip the initialization call](https://github.com/aragon/aragonOS/blob/07d309f5e81c768269dfc49373d41fac4528ebd2/contracts/apps/AppProxyBase.sol#L27) so we set up the address book initialization to be encoded and passed in for installation