### PR TITLE
Change projects `_repoId` to use fromHex

### DIFF
--- a/apps/projects/contracts/Projects.sol
+++ b/apps/projects/contracts/Projects.sol
@@ -357,7 +357,7 @@ contract Projects is AragonApp, DepositableStorage {
 // Repository functions
 ///////////////////////
     /**
-     * @notice Add repository `@fromHex(_repoId, "ascii")`
+     * @notice Add repository
      * @param _repoId The id of the repo in the projects registry
      * @return index for the added repo at the registry
      */
@@ -374,7 +374,7 @@ contract Projects is AragonApp, DepositableStorage {
     }
 
     /**
-     * @notice Remove repository `@fromHex(_repoId, "ascii")`
+     * @notice Remove repository
      * @param _repoId The id of the repo in the projects registry
      */
     function removeRepo(

--- a/apps/projects/contracts/Projects.sol
+++ b/apps/projects/contracts/Projects.sol
@@ -357,7 +357,7 @@ contract Projects is AragonApp, DepositableStorage {
 // Repository functions
 ///////////////////////
     /**
-     * @notice Add repository `_repoId`
+     * @notice Add repository `@fromHex(_repoId, "ascii")`
      * @param _repoId The id of the repo in the projects registry
      * @return index for the added repo at the registry
      */
@@ -374,7 +374,7 @@ contract Projects is AragonApp, DepositableStorage {
     }
 
     /**
-     * @notice Remove repository `_repoId`
+     * @notice Remove repository `@fromHex(_repoId, "ascii")`
      * @param _repoId The id of the repo in the projects registry
      */
     function removeRepo(


### PR DESCRIPTION
This PR resolves item #1 of the Mainnet UX Audit document:

> Improve radspec (adding project)
> We passed in the repo ID but it seems to be in bytes form vs. the actual ID used by Github.
> 
> 
> Solution (options):
> Remove this from the radspec since it’s not immediately useful
> Show the actual Github ID
> Add a metadata field in the contract that gets populated with the repo name when adding a project. In the future we can have an ‘updateProject’ contract call which allows user to “sync repo name” in the case of when a repo name was updated


This leverages solution #2, showing the actual Github ID (For example MDEwOlJlcG9zaXRvcnkxNzEyMjg2Mjk=)

Not sure that this is informative enough for the user.