### PR TITLE
Allocations: AragonUI version bump

### DIFF
--- a/apps/allocations/package.json
+++ b/apps/allocations/package.json
@@ -34,7 +34,7 @@
     "@aragon/api-react": "2.0.0-beta.6",
     "@aragon/apps-vault": "4.1.0",
     "@aragon/os": "4.2.0",
-    "@aragon/ui": "1.0.0-alpha.19",
+    "@aragon/ui": "1.0.0-alpha.26",
     "@babel/polyfill": "^7.2.5",
     "bignumber.js": "^7.2.1",
     "prop-types": "^15.7.2",


### PR DESCRIPTION
Upgraded AragonUI from 1.0.0-alpha.19 to 1.0.0-alpha.26 in order to improve the styling of the buttons in disabled mode.