### PR TITLE
Projects: perform Issues query less frequently

### DIFF
--- a/apps/projects/app/App.js
+++ b/apps/projects/app/App.js
@@ -14,6 +14,7 @@ import {
 
 import ErrorBoundary from './components/App/ErrorBoundary'
 import { Issues, Overview, Settings } from './components/Content'
+import IssueDetail from './components/Content/IssueDetail'
 import { PanelManager, PanelContext, usePanelManagement } from './components/Panel'
 
 import { IdentityProvider } from '../../../shared/identity'
@@ -35,7 +36,7 @@ const App = () => {
   const [ activeIndex, setActiveIndex ] = useState(
     { tabIndex: 0, tabData: {} }
   )
-  const [ issueDetail, setIssueDetail ] = useState(false)
+  const [ selectedIssue, setSelectedIssue ] = useState(null)
   const [ githubLoading, setGithubLoading ] = useState(false)
   const [ panel, setPanel ] = useState(null)
   const [ panelProps, setPanelProps ] = useState(null)
@@ -194,35 +195,39 @@ const App = () => {
                 <TabAction />
               }
             />
-
-            {issueDetail ?
-              <Bar>
-                <BackButton
-                  onClick={() => {setIssueDetail(false)}}
-                />
-              </Bar>
-              :
-              <Tabs
-                items={tabs.map(t => t.name)}
-                onChange={handleSelect}
-                selected={activeIndex.tabIndex}
-              />
-            }
-
             <ErrorBoundary>
-              <TabComponent
-                status={github.status}
-                app={api}
-                projects={repos}
-                bountyIssues={issues}
-                bountySettings={bountySettings}
-                tokens={tokens}
-                activeIndex={activeIndex}
-                changeActiveIndex={changeActiveIndex}
-                setIssueDetail={setIssueDetail}
-                issueDetail={issueDetail}
-                onLogin={handleGithubSignIn}
-              />
+
+              {selectedIssue
+                ? (
+                  <React.Fragment>
+                    <Bar>
+                      <BackButton onClick={() => setSelectedIssue(null)} />
+                    </Bar>
+                    <IssueDetail issue={selectedIssue} />
+                  </React.Fragment>
+                )
+                : (
+                  <React.Fragment>
+                    <Tabs
+                      items={tabs.map(t => t.name)}
+                      onChange={handleSelect}
+                      selected={activeIndex.tabIndex}
+                    />
+                    <TabComponent
+                      status={github.status}
+                      app={api}
+                      projects={repos}
+                      bountyIssues={issues}
+                      bountySettings={bountySettings}
+                      tokens={tokens}
+                      activeIndex={activeIndex}
+                      changeActiveIndex={changeActiveIndex}
+                      setSelectedIssue={setSelectedIssue}
+                      onLogin={handleGithubSignIn}
+                    />
+                  </React.Fragment>
+                )
+              }
             </ErrorBoundary>
 
             <PanelManager

--- a/apps/projects/app/components/Content/Issues.js
+++ b/apps/projects/app/components/Content/Issues.js
@@ -55,7 +55,9 @@ class Issues extends React.PureComponent {
     selectedIssues: {},
     allSelected: false,
     filters: {
-      projects: {},
+      projects: this.props.activeIndex.tabData.filterIssuesByRepoId
+        ? { [this.props.activeIndex.tabData.filterIssuesByRepoId]: true }
+        : {},
       labels: {},
       milestones: {},
       deadlines: {},
@@ -68,16 +70,6 @@ class Issues extends React.PureComponent {
     downloadedRepos: {},
     downloadedIssues: [],
     issuesPerCall: 100,
-  }
-
-  UNSAFE_componentWillMount() {
-    if ('filterIssuesByRepoId' in this.props.activeIndex.tabData) {
-      const { filters } = this.state
-      filters.projects[
-        this.props.activeIndex.tabData.filterIssuesByRepoId
-      ] = true
-      this.setState({ filters })
-    }
   }
 
   deselectAllIssues = () => {

--- a/apps/projects/app/components/Content/Issues.js
+++ b/apps/projects/app/components/Content/Issues.js
@@ -37,6 +37,7 @@ class Issues extends React.PureComponent {
     bountySettings: PropTypes.shape({
       expLvls: PropTypes.array.isRequired,
     }).isRequired,
+    downloadedRepos: PropTypes.object.isRequired,
     filters: PropTypes.object.isRequired,
     github: PropTypes.shape({
       status: PropTypes.oneOf([
@@ -48,6 +49,7 @@ class Issues extends React.PureComponent {
       event: PropTypes.string,
     }),
     projects: PropTypes.array.isRequired,
+    setDownloadedRepos: PropTypes.func.isRequired,
     setFilters: PropTypes.func.isRequired,
     setSelectedIssue: PropTypes.func.isRequired,
     shapeIssue: PropTypes.func.isRequired,
@@ -61,7 +63,6 @@ class Issues extends React.PureComponent {
     sortBy: 'Newest',
     textFilter: '',
     reload: false,
-    downloadedRepos: {},
     downloadedIssues: [],
   }
 
@@ -298,8 +299,8 @@ class Issues extends React.PureComponent {
     Object.keys(downloadedRepos).forEach(repoId => {
       newDownloadedRepos[repoId].showMore = downloadedRepos[repoId].hasNextPage
     })
+    this.props.setDownloadedRepos(newDownloadedRepos)
     this.setState({
-      downloadedRepos: newDownloadedRepos,
       downloadedIssues,
     })
   }
@@ -311,10 +312,10 @@ class Issues extends React.PureComponent {
     // and a cursor in there are 100+ issues and "Show More" was clicked.
     let reposQueryParams = {}
 
-    if (Object.keys(this.state.downloadedRepos).length > 0) {
-      Object.keys(this.state.downloadedRepos).forEach(repoId => {
-        if (this.state.downloadedRepos[repoId].hasNextPage)
-          reposQueryParams[repoId] = this.state.downloadedRepos[repoId]
+    if (Object.keys(this.props.downloadedRepos).length > 0) {
+      Object.keys(this.props.downloadedRepos).forEach(repoId => {
+        if (this.props.downloadedRepos[repoId].hasNextPage)
+          reposQueryParams[repoId] = this.props.downloadedRepos[repoId]
       })
     } else {
       if (Object.keys(filters.projects).length > 0) {
@@ -407,6 +408,7 @@ class Issues extends React.PureComponent {
 
 const IssuesWrap = ({ activeIndex, ...props }) => {
   const shapeIssue = useShapedIssue()
+  const [ downloadedRepos, setDownloadedRepos ] = useState({})
   const [ filters, setFilters ] = useState({
     projects: activeIndex.tabData.filterIssuesByRepoId
       ? { [activeIndex.tabData.filterIssuesByRepoId]: true }
@@ -421,7 +423,9 @@ const IssuesWrap = ({ activeIndex, ...props }) => {
   return (
     <Issues
       activeIndex={activeIndex}
+      downloadedRepos={downloadedRepos}
       filters={filters}
+      setDownloadedRepos={setDownloadedRepos}
       setFilters={setFilters}
       shapeIssue={shapeIssue}
       {...props}

--- a/apps/projects/app/components/Content/Issues.js
+++ b/apps/projects/app/components/Content/Issues.js
@@ -15,6 +15,17 @@ import { Issue } from '../Card'
 import { LoadingAnimation } from '../Shared'
 import { EmptyWrapper } from '../Shared'
 
+const sorters = {
+  'Name ascending': (i1, i2) =>
+    i1.title.toUpperCase() > i2.title.toUpperCase() ? 1 : -1,
+  'Name descending': (i1, i2) =>
+    i1.title.toUpperCase() > i2.title.toUpperCase() ? -1 : 1,
+  'Newest': (i1, i2) =>
+    compareDesc(new Date(i1.createdAt), new Date(i2.createdAt)),
+  'Oldest': (i1, i2) =>
+    compareAsc(new Date(i1.createdAt), new Date(i2.createdAt)),
+}
+
 class Issues extends React.PureComponent {
   static propTypes = {
     activeIndex: PropTypes.shape({
@@ -270,23 +281,6 @@ class Issues extends React.PureComponent {
     </StyledIssues>
   )
 
-  generateSorter = () => {
-    switch (this.state.sortBy) {
-    case 'Name ascending':
-      return (i1, i2) => {
-        return i1.title.toUpperCase() > i2.title.toUpperCase() ? 1 : -1
-      }
-    case 'Name descending':
-      return (i1, i2) => {
-        return i1.title.toUpperCase() > i2.title.toUpperCase() ? -1 : 1
-      }
-    case 'Newest':
-      return (i1, i2) => compareAsc(new Date(i1.createdAt), new Date(i2.createdAt))
-    case 'Oldest':
-      return (i1, i2) => compareDesc(new Date(i1.createdAt), new Date(i2.createdAt))
-    }
-  }
-
   /*
    Data obtained from github API is data.{repo}.issues.[nodes] and it needs
    flattening into one simple array of issues  before it can be used
@@ -335,8 +329,6 @@ class Issues extends React.PureComponent {
     const { projects } = this.props
 
     const { filters } = this.state
-
-    const currentSorter = this.generateSorter()
 
     // build params for GQL query, each repo to fetch has number of items to download,
     // and a cursor in there are 100+ issues and "Show More" was clicked.
@@ -397,7 +389,7 @@ class Issues extends React.PureComponent {
                 <IssuesScrollView>
                   <ScrollWrapper>
                     {issuesFiltered.map(this.props.shapeIssue)
-                      .sort(currentSorter)
+                      .sort(sorters[this.state.sortBy])
                       .map(issue => (
                         <Issue
                           isSelected={issue.id in this.state.selectedIssues}

--- a/apps/projects/app/components/Content/Issues.js
+++ b/apps/projects/app/components/Content/Issues.js
@@ -26,6 +26,8 @@ const sorters = {
     compareAsc(new Date(i1.createdAt), new Date(i2.createdAt)),
 }
 
+const ISSUES_PER_CALL = 100
+
 class Issues extends React.PureComponent {
   static propTypes = {
     activeIndex: PropTypes.shape({
@@ -61,7 +63,6 @@ class Issues extends React.PureComponent {
     reload: false,
     downloadedRepos: {},
     downloadedIssues: [],
-    issuesPerCall: 100,
   }
 
   deselectAllIssues = () => {
@@ -277,7 +278,7 @@ class Issues extends React.PureComponent {
       downloadedRepos[repo.id] = {
         downloadedCount: repo.issues.nodes.length,
         totalCount: repo.issues.totalCount,
-        fetch: this.state.issuesPerCall,
+        fetch: ISSUES_PER_CALL,
         hasNextPage: repo.issues.pageInfo.hasNextPage,
         endCursor: repo.issues.pageInfo.endCursor,
       }
@@ -319,7 +320,7 @@ class Issues extends React.PureComponent {
       if (Object.keys(filters.projects).length > 0) {
         Object.keys(filters.projects).forEach(repoId => {
           reposQueryParams[repoId] = {
-            fetch: this.state.issuesPerCall,
+            fetch: ISSUES_PER_CALL,
             showMore: false,
           }
         })
@@ -327,7 +328,7 @@ class Issues extends React.PureComponent {
         projects.forEach(project => {
           const repoId = project.data._repo
           reposQueryParams[repoId] = {
-            fetch: this.state.issuesPerCall,
+            fetch: ISSUES_PER_CALL,
             showMore: false,
           }
         })

--- a/apps/projects/app/hooks/useShapedIssue.js
+++ b/apps/projects/app/hooks/useShapedIssue.js
@@ -1,0 +1,53 @@
+import { useCallback } from 'react'
+import { useAragonApi } from '@aragon/api-react'
+import BigNumber from 'bignumber.js'
+
+export default () => {
+  const { appState } = useAragonApi()
+  const { tokens = [], bountyIssues = [], bountySettings = {} } = appState
+
+  const bountyIssueObj = {}
+  const tokenObj = {}
+  const expLevels = bountySettings.expLvls
+
+  bountyIssues.forEach(issue => {
+    bountyIssueObj[issue.issueNumber] = issue
+  })
+
+  tokens.forEach(token => {
+    tokenObj[token.addr] = {
+      symbol: token.symbol,
+      decimals: token.decimals,
+    }
+  })
+
+  const shapeIssue = useCallback(issue => {
+    const bountyId = bountyIssueObj[issue.number]
+    const repoIdFromBounty = bountyId && bountyId.data.repoId
+    if (bountyId && repoIdFromBounty === issue.repository.id) {
+      const data = bountyIssueObj[issue.number].data
+      const balance = BigNumber(bountyIssueObj[issue.number].data.balance)
+        .div(BigNumber(10 ** tokenObj[data.token].decimals))
+        .dp(3)
+        .toString()
+
+      return {
+        ...issue,
+        ...bountyIssueObj[issue.number].data,
+        repoId: issue.repository.id,
+        repo: issue.repository.name,
+        symbol: tokenObj[data.token].symbol,
+        expLevel: expLevels[data.exp].name,
+        balance: balance,
+        data,
+      }
+    }
+    return {
+      ...issue,
+      repoId: issue.repository.id,
+      repo: issue.repository.name,
+    }
+  }, [ tokens, bountyIssues, bountySettings ])
+
+  return shapeIssue
+}

--- a/apps/projects/package.json
+++ b/apps/projects/package.json
@@ -32,6 +32,7 @@
     "test:truffle": "./utils/test.sh"
   },
   "dependencies": {
+    "@apollo/react-hooks": "^3.1.3",
     "@aragon/api": "AutarkLabs/aragon-api",
     "@aragon/api-react": "2.0.0-beta.6",
     "@aragon/apps-shared-minime": "1.0.1",
@@ -42,6 +43,7 @@
     "@babel/runtime": "^7.6.0",
     "apollo-boost": "^0.1.22",
     "axios": "^0.18.0",
+    "date-fns": "2.0.0-alpha.22",
     "graphql": "^14.0.2",
     "graphql-request": "^1.8.2",
     "graphql-tag": "^2.10.0",
@@ -53,8 +55,7 @@
     "react-markdown": "^4.1.0",
     "react-number-format": "^4.0.8",
     "styled-components": "4.1.3",
-    "web3-utils": "^1.0.0",
-    "date-fns": "2.0.0-alpha.22"
+    "web3-utils": "^1.0.0"
   },
   "devDependencies": {
     "@aragon/test-helpers": "^1.0.1",


### PR DESCRIPTION
The main event: **Switch from `Query` higher-order component to `useQuery` hook.**

This required extracting not just one, but _two_ new functional components out of the `Issues` class component. I was hoping for just one, but we need to make sure we don't call the `useQuery` hook unless both `client` and `query` are defined. Since [hooks can't be conditional](https://reactjs.org/docs/hooks-overview.html#rules-of-hooks), the best path forward that I found was to have `IssuesWrap` render `IssuesQuery` only if these two variables are defined. `IssuesQuery`, then, calls `useQuery` and renders the simplified `Issues` component.

Read through the commits in order for deeper explanations of each specific bit of cleanup that was required to make this change.