### PR TITLE
Add --files to publish:http scripts

### DIFF
--- a/apps/address-book/package.json
+++ b/apps/address-book/package.json
@@ -17,7 +17,7 @@
     "prepublishOnly": "truffle compile --all",
     "publish": "aragon apm publish patch && sleep 3",
     "publish:cd": "yes | aragon apm publish major --files dist/ --environment continuous-deployment --apm.ipfs.rpc https://ipfs.autark.xyz:5001 --ipfs-check false --skip-confirmation true",
-    "publish:http": "npm run build:script && yes | aragon apm publish major --http localhost:1111 --http-served-from ./dist --propagate-content false --skip-confirmation true",
+    "publish:http": "npm run build:script && yes | aragon apm publish major --files dist --http localhost:1111 --http-served-from ./dist --propagate-content false --skip-confirmation true",
     "publish:major": "aragon apm publish major --files dist/",
     "publish:minor": "aragon apm publish minor --files dist/",
     "publish:patch": "aragon apm publish patch --files dist/",

--- a/apps/address-book/package.json
+++ b/apps/address-book/package.json
@@ -14,7 +14,7 @@
     "ganache-cli:test": "sh ../../node_modules/@aragon/test-helpers/ganache-cli.sh",
     "lint": "solium --dir ./contracts",
     "precommit": "lint-staged",
-    "prepublishOnly": "truffle compile --all",
+    "prepublishOnly": "truffle compile",
     "publish": "aragon apm publish patch && sleep 3",
     "publish:cd": "yes | aragon apm publish major --files dist/ --environment continuous-deployment --apm.ipfs.rpc https://ipfs.autark.xyz:5001 --ipfs-check false --skip-confirmation true",
     "publish:http": "npm run build:script && yes | aragon apm publish major --files dist --http localhost:1111 --http-served-from ./dist --propagate-content false --skip-confirmation true",

--- a/apps/allocations/package.json
+++ b/apps/allocations/package.json
@@ -16,7 +16,7 @@
     "precommit": "lint-staged",
     "prepublishOnly": "truffle compile --all",
     "publish:cd": "yes | aragon apm publish major --files dist/ --environment continuous-deployment --apm.ipfs.rpc https://ipfs.autark.xyz:5001 --ipfs-check false --skip-confirmation true",
-    "publish:http": "npm run build:script && yes | aragon apm publish major --http localhost:2222 --http-served-from ./dist --propagate-content false --skip-confirmation true",
+    "publish:http": "npm run build:script && yes | aragon apm publish major --files dist --http localhost:2222 --http-served-from ./dist --propagate-content false --skip-confirmation true",
     "publish": "aragon apm publish patch && sleep 3",
     "publish:major": "aragon apm publish major --files dist/",
     "publish:minor": "aragon apm publish minor --files dist/",

--- a/apps/allocations/package.json
+++ b/apps/allocations/package.json
@@ -14,7 +14,7 @@
     "ganache-cli:test": "../shared/test-helpers/ganache-cli.sh",
     "lint": "solium --dir ./contracts",
     "precommit": "lint-staged",
-    "prepublishOnly": "truffle compile --all",
+    "prepublishOnly": "truffle compile",
     "publish:cd": "yes | aragon apm publish major --files dist/ --environment continuous-deployment --apm.ipfs.rpc https://ipfs.autark.xyz:5001 --ipfs-check false --skip-confirmation true",
     "publish:http": "npm run build:script && yes | aragon apm publish major --files dist --http localhost:2222 --http-served-from ./dist --propagate-content false --skip-confirmation true",
     "publish": "aragon apm publish patch && sleep 3",

--- a/apps/discussions/package.json
+++ b/apps/discussions/package.json
@@ -54,7 +54,7 @@
     "build:app": "parcel build ./app/index.html -d dist/ --public-url \".\" --no-cache",
     "build:script": "parcel build ./app/script.js -d dist/ --no-cache",
     "publish:cd": "yes | aragon apm publish major --files dist/ --environment continuous-deployment --apm.ipfs.rpc https://ipfs.autark.xyz:5001 --ipfs-check false --skip-confirmation true",
-    "publish:http": "npm run build:script && yes | aragon apm publish major --http localhost:9999 --http-served-from ./dist --propagate-content false --skip-confirmation true",
+    "publish:http": "npm run build:script && yes | aragon apm publish major --files dist --http localhost:9999 --http-served-from ./dist --propagate-content false --skip-confirmation true",
     "publish:patch": "aragon apm publish patch",
     "publish:minor": "aragon apm publish minor",
     "publish:major": "aragon apm publish major",

--- a/apps/dot-voting/package.json
+++ b/apps/dot-voting/package.json
@@ -14,7 +14,7 @@
     "ganache-cli:test": "sh ../../node_modules/@aragon/test-helpers/ganache-cli.sh",
     "lint": "solium --dir ./contracts",
     "precommit": "lint-staged",
-    "prepublishOnly": "truffle compile --all",
+    "prepublishOnly": "truffle compile",
     "publish:cd": "yes | aragon apm publish major --files dist/ --environment continuous-deployment --apm.ipfs.rpc https://ipfs.autark.xyz:5001 --ipfs-check false --skip-confirmation true",
     "publish:http": "npm run build:script && yes | aragon apm publish major --files dist --http localhost:4444 --http-served-from ./dist --propagate-content false --skip-confirmation true",
     "publish": "aragon apm publish patch && sleep 3",

--- a/apps/dot-voting/package.json
+++ b/apps/dot-voting/package.json
@@ -16,7 +16,7 @@
     "precommit": "lint-staged",
     "prepublishOnly": "truffle compile --all",
     "publish:cd": "yes | aragon apm publish major --files dist/ --environment continuous-deployment --apm.ipfs.rpc https://ipfs.autark.xyz:5001 --ipfs-check false --skip-confirmation true",
-    "publish:http": "npm run build:script && yes | aragon apm publish major --http localhost:4444 --http-served-from ./dist --propagate-content false --skip-confirmation true",
+    "publish:http": "npm run build:script && yes | aragon apm publish major --files dist --http localhost:4444 --http-served-from ./dist --propagate-content false --skip-confirmation true",
     "publish": "aragon apm publish patch && sleep 3",
     "publish:major": "aragon apm publish major --files dist/",
     "publish:minor": "aragon apm publish minor --files dist/",

--- a/apps/projects/package.json
+++ b/apps/projects/package.json
@@ -15,7 +15,7 @@
     "ganache-cli:test:orig": "../shared/test-helpers/ganache-cli.sh",
     "lint": "solium --dir ./contracts",
     "precommit": "lint-staged",
-    "prepublishOnly": "truffle compile --all",
+    "prepublishOnly": "truffle compile",
     "publish": "aragon apm publish patch && sleep 3",
     "publish:cd": "yes | aragon apm publish major --files dist/ --environment continuous-deployment --apm.ipfs.rpc https://ipfs.autark.xyz:5001 --ipfs-check false --skip-confirmation true",
     "publish:http": "npm run build:script && yes | aragon apm publish major --files dist --http localhost:3333 --http-served-from ./dist --propagate-content false --skip-confirmation true",

--- a/apps/projects/package.json
+++ b/apps/projects/package.json
@@ -18,7 +18,7 @@
     "prepublishOnly": "truffle compile --all",
     "publish": "aragon apm publish patch && sleep 3",
     "publish:cd": "yes | aragon apm publish major --files dist/ --environment continuous-deployment --apm.ipfs.rpc https://ipfs.autark.xyz:5001 --ipfs-check false --skip-confirmation true",
-    "publish:http": "npm run build:script && yes | aragon apm publish major --http localhost:3333 --http-served-from ./dist --propagate-content false --skip-confirmation true",
+    "publish:http": "npm run build:script && yes | aragon apm publish major --files dist --http localhost:3333 --http-served-from ./dist --propagate-content false --skip-confirmation true",
     "publish:major": "aragon apm publish major --files dist/",
     "publish:minor": "aragon apm publish minor --files dist/",
     "publish:patch": "aragon apm publish patch --files dist/",

--- a/apps/rewards/package.json
+++ b/apps/rewards/package.json
@@ -14,7 +14,7 @@
     "ganache-cli:test": "sh ../../node_modules/@aragon/test-helpers/ganache-cli.sh",
     "lint": "solium --dir ./contracts",
     "precommit": "lint-staged",
-    "prepublishOnly": "truffle compile --all",
+    "prepublishOnly": "truffle compile",
     "publish": "aragon apm publish patch && sleep 3",
     "publish:cd": "yes | aragon apm publish major --files dist/ --environment continuous-deployment --apm.ipfs.rpc https://ipfs.autark.xyz:5001 --ipfs-check false --skip-confirmation true",
     "publish:http": "npm run build:script && yes | aragon apm publish major --files dist --http localhost:5555 --http-served-from ./dist --propagate-content false --skip-confirmation true",

--- a/apps/rewards/package.json
+++ b/apps/rewards/package.json
@@ -17,7 +17,7 @@
     "prepublishOnly": "truffle compile --all",
     "publish": "aragon apm publish patch && sleep 3",
     "publish:cd": "yes | aragon apm publish major --files dist/ --environment continuous-deployment --apm.ipfs.rpc https://ipfs.autark.xyz:5001 --ipfs-check false --skip-confirmation true",
-    "publish:http": "npm run build:script && yes | aragon apm publish major --http localhost:5555 --http-served-from ./dist --propagate-content false --skip-confirmation true",
+    "publish:http": "npm run build:script && yes | aragon apm publish major --files dist --http localhost:5555 --http-served-from ./dist --propagate-content false --skip-confirmation true",
     "publish:major": "aragon apm publish major --files dist/",
     "publish:minor": "aragon apm publish minor --files dist/",
     "publish:patch": "aragon apm publish patch --files dist/",

--- a/templates/dev/package.json
+++ b/templates/dev/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "prepublishOnly": "npm run compile && npm run abi:extract -- --no-compile",
     "abi:extract": "truffle-extract --output abi/ --keys abi",
-    "compile": "truffle compile --all",
+    "compile": "truffle compile",
     "lint": "solium --dir ./contracts",
     "coverage": "SOLIDITY_COVERAGE=true npm run test",
     "test": "npm run test:ganache",

--- a/templates/open-enterprise/package.json
+++ b/templates/open-enterprise/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "prepublishOnly": "npm run compile && npm run abi:extract -- --no-compile",
     "abi:extract": "truffle-extract --output abi/ --keys abi",
-    "compile": "truffle compile --all",
+    "compile": "truffle compile",
     "lint": "solium --dir ./contracts",
     "coverage": "SOLIDITY_COVERAGE=true npm run test",
     "test": "npm run test:ganache",


### PR DESCRIPTION
This small PR adds the option to `publish:http`, that prevents publishing the whole app folder, that will solve 2 main issues:
- The large `apm` package size, that also takes more space in the hard disk
- The extra-time needed to add those files that are not needed to be in the package

Even `aragon-cli` suggests to do so:
![image](https://user-images.githubusercontent.com/5030059/66976453-f6775d80-f0dc-11e9-9e90-968b90d0d5a3.png)

In the future I think we should move our publish commands to an external script to have better readability/maintainability and deduplicate a bit, but for now this will help a bit, even in publish:http!


---

The second part of this PR just removes `--all` from every `truffle compile` call, since truffle automatically detects which contract changed to compile again, we are basically overriding this smart behavior to force compiling every contract each time! that is really a ton of unnecessarily wasted time, when `--all` should just be used for debugging purposes.

source: https://www.trufflesuite.com/docs/truffle/getting-started/compiling-contracts#command
