### PR TITLE
Address Book: remove custom types

### DIFF
--- a/apps/address-book/app/components/Panel/NewEntity.js
+++ b/apps/address-book/app/components/Panel/NewEntity.js
@@ -7,7 +7,7 @@ import web3Utils from 'web3-utils'
 
 const isCustomType = type => type === 'Custom type...'
 
-const ENTITY_TYPES = [ 'Individual', 'Organization', 'Project', 'Custom type...' ]
+const ENTITY_TYPES = [ 'Individual', 'Organization', 'Project' ]
 const INITIAL_STATE = {
   name: '',
   address: '',


### PR DESCRIPTION
Remove custom types from the "type" dropdown menu. This is a temporary measure while this feature gets implemented.