### PR TITLE
Projects: stop making GitHub queries in script.js

### DIFF
--- a/apps/projects/app/App.js
+++ b/apps/projects/app/App.js
@@ -30,6 +30,7 @@ import Unauthorized from './components/Content/Unauthorized'
 import { LoadingAnimation } from './components/Shared'
 import { EmptyWrapper } from './components/Shared'
 import { Error } from './components/Card'
+import { DecoratedReposProvider } from './context/DecoratedRepos'
 
 const App = () => {
   const { api, appState } = useAragonApi()
@@ -183,52 +184,53 @@ const App = () => {
             onResolve={handleResolveLocalIdentity}
             onShowLocalIdentityModal={handleShowLocalIdentityModal}
           >
-            <Header
-              primary="Projects"
-              secondary={
-                <TabAction />
-              }
-            />
-            <ErrorBoundary>
+            <DecoratedReposProvider>
+              <Header
+                primary="Projects"
+                secondary={
+                  <TabAction />
+                }
+              />
+              <ErrorBoundary>
 
-              {selectedIssue
-                ? (
-                  <React.Fragment>
-                    <Bar>
-                      <BackButton onClick={() => setSelectedIssue(null)} />
-                    </Bar>
-                    <IssueDetail issue={selectedIssue} />
-                  </React.Fragment>
-                )
-                : (
-                  <React.Fragment>
-                    <Tabs
-                      items={tabs.map(t => t.name)}
-                      onChange={handleSelect}
-                      selected={activeIndex.tabIndex}
-                    />
-                    <TabComponent
-                      status={github.status}
-                      app={api}
-                      projects={repos}
-                      bountyIssues={issues}
-                      bountySettings={bountySettings}
-                      tokens={tokens}
-                      activeIndex={activeIndex}
-                      changeActiveIndex={changeActiveIndex}
-                      setSelectedIssue={setSelectedIssue}
-                      onLogin={handleGithubSignIn}
-                    />
-                  </React.Fragment>
-                )
-              }
-            </ErrorBoundary>
+                {selectedIssue
+                  ? (
+                    <React.Fragment>
+                      <Bar>
+                        <BackButton onClick={() => setSelectedIssue(null)} />
+                      </Bar>
+                      <IssueDetail issue={selectedIssue} />
+                    </React.Fragment>
+                  )
+                  : (
+                    <React.Fragment>
+                      <Tabs
+                        items={tabs.map(t => t.name)}
+                        onChange={handleSelect}
+                        selected={activeIndex.tabIndex}
+                      />
+                      <TabComponent
+                        status={github.status}
+                        app={api}
+                        bountyIssues={issues}
+                        bountySettings={bountySettings}
+                        tokens={tokens}
+                        activeIndex={activeIndex}
+                        changeActiveIndex={changeActiveIndex}
+                        setSelectedIssue={setSelectedIssue}
+                        onLogin={handleGithubSignIn}
+                      />
+                    </React.Fragment>
+                  )
+                }
+              </ErrorBoundary>
 
-            <PanelManager
-              activePanel={panel}
-              onClose={closePanel}
-              {...panelProps}
-            />
+              <PanelManager
+                activePanel={panel}
+                onClose={closePanel}
+                {...panelProps}
+              />
+            </DecoratedReposProvider>
           </IdentityProvider>
         </PanelContext.Provider>
       </ApolloProvider>

--- a/apps/projects/app/api-react.js
+++ b/apps/projects/app/api-react.js
@@ -1,3 +1,4 @@
+import { hexToAscii } from 'web3-utils'
 import buildStubbedApiReact from '../../../shared/api-react'
 import { STATUS } from './utils/github'
 import {
@@ -5,10 +6,6 @@ import {
   REQUESTED_GITHUB_DISCONNECT,
 } from './store/eventTypes'
 import { INITIAL_STATE } from './store/index'
-import {
-  initializeGraphQLClient,
-  getRepoData,
-} from './store/helpers'
 
 const initialState = process.env.NODE_ENV !== 'production' && {
   repos: [],
@@ -58,28 +55,16 @@ const initialState = process.env.NODE_ENV !== 'production' && {
 }
 
 const functions = process.env.NODE_ENV !== 'production' && ((appState, setAppState) => ({
-  addRepo: async repoIdHex => {
-    const { token } = appState.github
-    if (!token) return
-
-    initializeGraphQLClient(token)
-    const { _repo, ...metadata } = await getRepoData(repoIdHex)
-
-    setAppState({
-      ...appState,
-      repos: [
-        ...appState.repos,
-        {
-          id: repoIdHex,
-          metadata,
-          data: {
-            _repo,
-            index: undefined,
-          },
-        },
-      ]
-    })
-  },
+  addRepo: repoIdHex => setAppState({
+    ...appState,
+    repos: [
+      ...appState.repos,
+      {
+        id: repoIdHex,
+        data: { _repo: hexToAscii(repoIdHex) },
+      },
+    ]
+  }),
   trigger: (event, { status, token }) => {
     switch (event) {
     case REQUESTED_GITHUB_TOKEN_SUCCESS:

--- a/apps/projects/app/components/Content/Issues.js
+++ b/apps/projects/app/components/Content/Issues.js
@@ -377,8 +377,8 @@ IssuesQuery.propTypes = {
   query: PropTypes.object.isRequired,
 }
 
-const IssuesWrap = ({ activeIndex, projects, ...props }) => {
-  const { appState: { github } } = useAragonApi()
+const IssuesWrap = ({ activeIndex, ...props }) => {
+  const { appState: { github, repos } } = useAragonApi()
   const shapeIssue = useShapedIssue()
   const [ client, setClient ] = useState(null)
   const [ downloadedRepos, setDownloadedRepos ] = useState({})
@@ -413,8 +413,8 @@ const IssuesWrap = ({ activeIndex, projects, ...props }) => {
           }
         })
       } else {
-        projects.forEach(project => {
-          const repoId = project.data._repo
+        repos.forEach(repo => {
+          const repoId = repo.data._repo
           reposQueryParams[repoId] = {
             fetch: ISSUES_PER_CALL,
             showMore: false,
@@ -424,7 +424,7 @@ const IssuesWrap = ({ activeIndex, projects, ...props }) => {
     }
 
     setQuery(getIssuesGQL(reposQueryParams))
-  }, [ downloadedRepos, filters, projects ])
+  }, [ downloadedRepos, filters, repos ])
 
   useEffect(() => {
     setClient(github.token ? initApolloClient(github.token) : null)
@@ -454,7 +454,6 @@ IssuesWrap.propTypes = {
       filterIssuesByRepoId: PropTypes.string,
     }).isRequired,
   }).isRequired,
-  projects: PropTypes.array.isRequired,
 }
 
 const StyledIssues = styled.div`

--- a/apps/projects/app/components/Content/Overview.js
+++ b/apps/projects/app/components/Content/Overview.js
@@ -5,28 +5,29 @@ import styled from 'styled-components'
 import { Project, Empty } from '../Card'
 import { useLayout } from '@aragon/ui'
 import { CARD_STRETCH_BREAKPOINT } from '../../utils/responsive'
+import { useDecoratedRepos } from '../../context/DecoratedRepos'
 
-const Overview = ({ changeActiveIndex, projects }) => {
+const Overview = ({ changeActiveIndex }) => {
   const { width } = useLayout()
+  const repos = useDecoratedRepos()
 
-  const projectsCards = useCallback(projects.map((project, index) => (
+  const projectsCards = useCallback(repos.map(repo => (
     <Project
-      key={index}
-      label={project.metadata.name}
-      description={project.metadata.description}
-      id={project.id}
-      repoId={project.data._repo}
-      commits={project.metadata.commits}
+      key={repo.id}
+      label={repo.metadata.name}
+      description={repo.metadata.description}
+      id={repo.id}
+      repoId={repo.data._repo}
+      commits={repo.metadata.commits}
       // TODO: Disabled for now
-      // contributors={project.metadata.collaborators}
-      url={project.metadata.url}
+      // contributors={repo.metadata.collaborators}
+      url={repo.metadata.url}
       changeActiveIndex={changeActiveIndex}
     />
-  ), [projects]
+  ), [repos]
   ))
 
-  const projectsEmpty = projects.length === 0
-  if (projectsEmpty) {
+  if (!repos.length) {
     return <Empty />
   }
 
@@ -39,7 +40,6 @@ const Overview = ({ changeActiveIndex, projects }) => {
 
 Overview.propTypes = {
   changeActiveIndex: PropTypes.func.isRequired,
-  projects: PropTypes.arrayOf(PropTypes.object).isRequired,
 }
 
 const StyledProjects = styled.div`

--- a/apps/projects/app/components/Panel/NewIssue/NewIssue.js
+++ b/apps/projects/app/components/Panel/NewIssue/NewIssue.js
@@ -6,7 +6,7 @@ import { NEW_ISSUE, GET_ISSUES } from '../../../utils/gql-queries.js'
 import { Form } from '../../Form'
 import { LoadingAnimation } from '../../Shared'
 import { usePanelManagement } from '../../Panel'
-import { useAragonApi } from '../../../api-react'
+import { useDecoratedRepos } from '../../../context/DecoratedRepos'
 
 // TODO: labels
 // TODO: import validator from '../data/validation'
@@ -176,14 +176,14 @@ class NewIssue extends React.PureComponent {
 // the following was a quick way to allow us to use hooks
 const NewIssueWrap = () => {
   const { closePanel } = usePanelManagement()
-  const { appState: { repos } } = useAragonApi()
+  const repos = useDecoratedRepos()
   const repoNames = repos
     ? repos.map(repo => ({
       name: repo.metadata.name,
       id: repo.data._repo,
     }))
     : 'No repos'
-  const reposIds = (repos || []).map(repo => repo.data.repo)
+  const reposIds = (repos || []).map(repo => repo.data._repo)
 
   return (
     <NewIssue

--- a/apps/projects/app/context/DecoratedRepos.js
+++ b/apps/projects/app/context/DecoratedRepos.js
@@ -1,0 +1,90 @@
+import React from 'react'
+import { useAragonApi } from '@aragon/api-react'
+import { GraphQLClient } from 'graphql-request'
+
+const repoQuery = repoId => `{
+  node(id: "${repoId}") {
+    ... on Repository {
+      name
+      url
+      description
+      defaultBranchRef {
+        target {
+          ...on Commit {
+            history {
+              totalCount
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+const DecoratedReposContext = React.createContext()
+
+export function useDecoratedRepos() {
+  const context = React.useContext(DecoratedReposContext)
+  if (!context) {
+    throw new Error('useDecoratedRepos must be used within a DecoratedReposProvider')
+  }
+  return context
+}
+
+export function DecoratedReposProvider(props) {
+  const { appState: { github, repos } } = useAragonApi()
+  const [ decoratedRepos, setDecoratedRepos ] = React.useState([])
+
+  React.useEffect(() => {
+    if (!github.token) return
+
+    async function fetchGithubData() {
+      const client = new GraphQLClient('https://api.github.com/graphql', {
+        headers: {
+          Authorization: 'Bearer ' + github.token,
+        },
+      })
+
+      setDecoratedRepos(await Promise.all(
+        // initial repo shape:
+        // {
+        //   id: repoIdHex,
+        //   data: { _repo: repoIdAscii },
+        // },
+        repos.map(repo => client.request(repoQuery(repo.data._repo))
+          .then(({ node }) => ({
+            id: repo.id,
+            data: { _repo: repo.data._repo },
+            metadata: {
+              name: node.name,
+              url: node.url,
+              description: node.description
+                ? node.description
+                : '(no description available)',
+              // TODO: disabled for now (apparently needs push permission on the repo to work)
+              collaborators: 0, //node.collaborators.totalCount,
+              commits: node.defaultBranchRef
+                ? node.defaultBranchRef.target.history.totalCount
+                : 0,
+            },
+          }))
+          .catch(err => ({
+            id: repo.id,
+            data: { _repo: repo.data._repo },
+            metadata: {
+              name: JSON.stringify(err),
+              url: '',
+              description: '',
+              collaborators: 0,
+              commits: 0,
+            },
+          }))
+        )
+      ))
+    }
+
+    fetchGithubData()
+  }, [ github.token, repos ])
+
+  return <DecoratedReposContext.Provider value={decoratedRepos} {...props} />
+}

--- a/apps/projects/app/store/events.js
+++ b/apps/projects/app/store/events.js
@@ -22,9 +22,7 @@ import {
 import { INITIAL_STATE } from './'
 
 import {
-  initializeGraphQLClient,
   syncRepos,
-  loadReposFromQueue,
   loadIssueData,
   loadIpfsData,
   buildSubmission,
@@ -61,17 +59,12 @@ export const handleEvent = async (state, action, vaultAddress, vaultContract) =>
     const { token } = returnValues
     if (!token) return state
 
-    initializeGraphQLClient(token)
-
     state.github = {
       token,
       status: STATUS.AUTHENTICATED,
       event: null
     }
     app.cache('github', state.github).toPromise()
-
-    const loadedRepos = await loadReposFromQueue(state)
-    state.repos = [ ...state.repos, ...loadedRepos ]
 
     return state
   }
@@ -81,7 +74,6 @@ export const handleEvent = async (state, action, vaultAddress, vaultContract) =>
   case REQUESTED_GITHUB_DISCONNECT: {
     state.github = INITIAL_STATE.github
     app.cache('github', state.github).toPromise()
-    state.repos = [] // repos will be reloaded from loadReposFromQueue on re-sign-in
     return state
   }
   case REPO_ADDED: {

--- a/apps/projects/app/store/helpers/repos.js
+++ b/apps/projects/app/store/helpers/repos.js
@@ -1,100 +1,19 @@
-import { GraphQLClient } from 'graphql-request'
-
+import { hexToAscii } from 'web3-utils'
 import { app } from '../app'
 
-let unloadedRepoQueue = []
-
-const toAscii = hex => {
-  // Find termination
-  let str = ''
-  let i = 0,
-    l = hex.length
-  if (hex.substring(0, 2) === '0x') {
-    i = 2
-  }
-  for (; i < l; i += 2) {
-    let code = parseInt(hex.substr(i, 2), 16)
-    str += String.fromCharCode(code)
-  }
-
-  return str
-}
-
-const repoData = id => `{
-    node(id: "${id}") {
-      ... on Repository {
-        name
-        url
-        description
-        defaultBranchRef {
-            target {
-              ...on Commit {
-                history {
-                  totalCount
-                }
-              }
-            }
-          }
-        }
-      }
-}`
-
-// collaborators {
-//   totalCount
-// }
-
-let graphQLClient = null
-
-export const initializeGraphQLClient = token => {
-  graphQLClient = new GraphQLClient('https://api.github.com/graphql', {
-    headers: {
-      Authorization: 'Bearer ' + token,
-    },
-  })
-}
-
-export const getRepoData = async repoIdHex => {
-  try {
-    const repoId = toAscii(repoIdHex)
-
-    let { node } = await graphQLClient.request(repoData(repoId))
-    const commits = node.defaultBranchRef
-      ? node.defaultBranchRef.target.history.totalCount
-      : 0
-    const description = node.description
-      ? node.description
-      : '(no description available)'
-    return {
-      _repo: repoId,
-      name: node.name,
-      url: node.url,
-      description: description,
-      // TODO: disabled for now (apparently needs push permission on the repo to work)
-      collaborators: 0, //node.collaborators.totalCount,
-      commits,
-    }
-  } catch (err) {
-    console.error('getRepoData failed: ', err)
-  }
-}
-
 const loadRepoData = id => {
-  return new Promise(async(resolve) => {
+  return new Promise(resolve => {
     app.call('isRepoAdded', id).subscribe(isAddedResponse => {
       if(!isAddedResponse) {
         return resolve({ repoRemoved: true })
       }
       app.call('getRepo', id).subscribe(response => {
-      // handle repo removed case
+        // handle repo removed case
         if (!response) return resolve({ repoRemoved: true })
 
-        getRepoData(id).then(({ _repo, ...metadata }) => {
-          return resolve({
-            _repo,
-            index: response.index, // always `undefined`
-            metadata,
-            repoRemoved: false,
-          })
+        return resolve({
+          _repo: hexToAscii(id),
+          repoRemoved: false,
         })
       })
     })
@@ -103,7 +22,7 @@ const loadRepoData = id => {
 
 const checkReposLoaded = async (repos, id, transform) => {
   const repoIndex = repos.findIndex(repo => repo.id === id)
-  const { metadata, repoRemoved, ...data } = await loadRepoData(id)
+  const { repoRemoved, ...data } = await loadRepoData(id)
 
   if (repoRemoved) return repos
 
@@ -113,7 +32,6 @@ const checkReposLoaded = async (repos, id, transform) => {
       await transform({
         id,
         data: { ...data },
-        metadata,
       })
     )
   }
@@ -122,22 +40,15 @@ const checkReposLoaded = async (repos, id, transform) => {
   nextRepos[repoIndex] = await transform({
     id,
     data: { ...data },
-    metadata,
   })
   return nextRepos
 }
 
 const updateState = async (state, id, transform) => {
   try {
-    if (graphQLClient) {
-      const repos = await checkReposLoaded(state.repos, id, transform)
-      const newState = { ...state, repos }
-      return newState
-    }
-
-    // if the user hasn't logged in to github, add the repos to a queue to load later
-    if(!unloadedRepoQueue.includes(id)) unloadedRepoQueue.push(id)
-    return state
+    const repos = await checkReposLoaded(state.repos, id, transform)
+    const newState = { ...state, repos }
+    return newState
   } catch (err) {
     console.error(
       'Update repos failed to return:',
@@ -158,18 +69,4 @@ export const syncRepos = async (state, { repoId }) => {
     console.error('updateState failed to return:', err)
     return state
   }
-}
-
-export const loadReposFromQueue = async state => {
-  if (unloadedRepoQueue && unloadedRepoQueue.length > 0) {
-    const loadedRepoQueue = await Promise.all(
-      unloadedRepoQueue.map(async repoId => {
-        const { repos } = await syncRepos(state, { repoId })
-        return repos[0]
-      })
-    )
-    // don't put a removed repo in state as `null`
-    return loadedRepoQueue.filter(repo => !!repo)
-  }
-  return []
 }

--- a/apps/projects/app/store/init.js
+++ b/apps/projects/app/store/init.js
@@ -1,7 +1,7 @@
 import vaultAbi from '../../../shared/json-abis/vault'
 import standardBounties from '../abi/StandardBounties.json'
 import { app, handleEvent, INITIAL_STATE } from './'
-import { initializeTokens, initializeGraphQLClient } from './helpers'
+import { initializeTokens } from './helpers'
 
 export const initStore = (vaultAddress, standardBountiesAddress) => {
   const vaultContract = app.external(vaultAddress, vaultAbi.abi)
@@ -36,7 +36,6 @@ const initState = (vaultContract) => async (cachedState) => {
   const github = await app.getCache('github').toPromise()
   if (github && github.token) {
     nextState.github = github
-    initializeGraphQLClient(github.token)
   }
 
   return { ...nextState }


### PR DESCRIPTION
Since we can't be confident that the user is logged in at the time events are read from the blockchain,

And since we can't be sure we'll see these events again due to how aragonAPI's store caching works,

We want everything in the appState reducer (aka script.js) to rely only on blockchain and IPFS data.

This means that the other data in `repos` needs to be loaded in on the frontend, once we know that the user has logged into GitHub.

Note that this architecture uses a `globalDecoratedRepos` variable, defined at the top level of the new `hooks/useRepos` file. This ensures that the first frontend component that needs to decorate repos (which happens to be App.js) will update this file-global variable, and subsequent components that need decorated repos can avoid unnecessary API calls to GitHub.

**Recommendation:** view the file changes [with indentation changes ignored](./1360/files?w=1)