### PR TITLE
Fix path resolution for the new syncing empty card

### DIFF
--- a/shared/ui/components/assets/components/Empty.js
+++ b/shared/ui/components/assets/components/Empty.js
@@ -1,3 +1,6 @@
+import React from 'react'
+
+const Empty = () => (
 <svg width="223" height="174" viewBox="0 0 223 174" fill="none" xmlns="http://www.w3.org/2000/svg">
 <g clip-path="url(#clip0)">
 <path opacity="0.1" d="M78.2247 170.63C99.7081 170.63 117.124 167.34 117.124 163.281C117.124 159.223 99.7081 155.933 78.2247 155.933C56.7413 155.933 39.3255 159.223 39.3255 163.281C39.3255 167.34 56.7413 170.63 78.2247 170.63Z" fill="#78D7EB"/>
@@ -110,3 +113,6 @@
 </clipPath>
 </defs>
 </svg>
+)
+
+export default Empty

--- a/shared/ui/components/assets/components/SyncCard.js
+++ b/shared/ui/components/assets/components/SyncCard.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react'
 import { Button, EmptyStateCard, GU, LoadingRing } from '@aragon/ui'
-import empty from '../svg/empty.svg'
+import Empty from './Empty'
 
 export default () => (
   <EmptyStateCard
@@ -26,7 +26,7 @@ export default () => (
             margin: auto;
             height: 170px;
           `}
-          src={empty}
+          src={Empty}
           alt="Syncing your project data. Hang tight homie!"
         />
       }


### PR DESCRIPTION
The empty svg was causing import issues in Rewards, an App that doesn't
even directly import it. I converted it into a React component and moved
it into the proper folder after doing so, and this seems to have fixed the
issue of the import issue in the Rewards App.js file