### PR TITLE
Allocations: add LocalIdentityBadge in Allocations history

### DIFF
--- a/apps/allocations/app/components/App/AllocationsHistory.js
+++ b/apps/allocations/app/components/App/AllocationsHistory.js
@@ -4,11 +4,11 @@ import {
   DataView,
   IconCheck,
   IconCross,
-  IdentityBadge,
   ProgressBar,
   Text,
   useTheme,
 } from '@aragon/ui'
+import LocalIdentityBadge from '../LocalIdentityBadge/LocalIdentityBadge'
 import { BigNumber } from 'bignumber.js'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
@@ -74,7 +74,7 @@ const AllocationsHistory = ({ allocations }) => {
           const allocated = BigNumber(recipient.supports).div(totalSupports)
           return (
             <div key={index}>
-              <IdentityBadge
+              <LocalIdentityBadge
                 entity={recipient.candidateAddress}
               />
               <RecipientProgress theme={theme}>

--- a/apps/allocations/app/components/App/AllocationsHistory.js
+++ b/apps/allocations/app/components/App/AllocationsHistory.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useAppState } from '@aragon/api-react'
+import { useAppState, useNetwork } from '@aragon/api-react'
 import {
   DataView,
   IconCheck,
@@ -19,6 +19,7 @@ import { displayCurrency } from '../../utils/helpers'
 const AllocationsHistory = ({ allocations }) => {
   const theme = useTheme()
   const { balances = [], budgets = [] } = useAppState()
+  const network = useNetwork()
   const getTokenSymbol = inputAddress => {
     const matchingBalance = balances.find(({ address }) => inputAddress === address)
     return matchingBalance ? matchingBalance.symbol : ''
@@ -76,6 +77,7 @@ const AllocationsHistory = ({ allocations }) => {
             <div key={index}>
               <LocalIdentityBadge
                 entity={recipient.candidateAddress}
+                networkType={network && network.type}
               />
               <RecipientProgress theme={theme}>
                 <ProgressBar

--- a/apps/allocations/app/components/App/App.js
+++ b/apps/allocations/app/components/App/App.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { useAragonApi } from '../../api-react'
 import { Button, Header, IconPlus, Main, SidePanel } from '@aragon/ui'
 
-import { IdentityProvider } from '../../../../../shared/identity'
+import { IdentityProvider } from '../LocalIdentityBadge/IdentityManager'
 import { Empty } from '../Card'
 import { NewAllocation, NewBudget } from '../Panel'
 import { AllocationsHistory, Budgets } from '.'

--- a/apps/allocations/app/components/LocalIdentityBadge/IdentityManager.js
+++ b/apps/allocations/app/components/LocalIdentityBadge/IdentityManager.js
@@ -1,0 +1,69 @@
+import React, { useCallback, useContext, useEffect, useState } from 'react'
+import PropTypes from 'prop-types'
+import { Subject } from 'rxjs'
+
+const updates$ = new Subject()
+
+const IdentityContext = React.createContext({
+  resolve: () =>
+    Promise.reject(Error('Please set resolve using IdentityProvider')),
+})
+
+function useIdentity(address) {
+  const [ name, setName ] = useState(null)
+  const { resolve, updates$, showLocalIdentityModal } = useContext(
+    IdentityContext
+  )
+
+  const handleNameChange = useCallback(metadata => {
+    setName(metadata ? metadata.name : null)
+  }, [])
+
+  const handleShowLocalIdentityModal = useCallback(
+    address => {
+      // Emit an event whenever the modal is closed (when the promise resolves)
+      return showLocalIdentityModal(address)
+        .then(() => updates$.next(address))
+        .catch(() => null)
+    },
+    [ showLocalIdentityModal, updates$ ]
+  )
+
+  useEffect(() => {
+    resolve(address).then(handleNameChange)
+
+    const subscription = updates$.subscribe(updatedAddress => {
+      if (updatedAddress.toLowerCase() === address.toLowerCase()) {
+        // Resolve and update state when the identity have been updated
+        resolve(address).then(handleNameChange)
+      }
+    })
+    return () => subscription.unsubscribe()
+  }, [ address, handleNameChange, updates$ ])
+
+  return [ name, handleShowLocalIdentityModal ]
+}
+
+const IdentityProvider = ({
+  onResolve,
+  onShowLocalIdentityModal,
+  children,
+}) => (
+  <IdentityContext.Provider
+    value={{
+      resolve: onResolve,
+      showLocalIdentityModal: onShowLocalIdentityModal,
+      updates$,
+    }}
+  >
+    {children}
+  </IdentityContext.Provider>
+)
+
+IdentityProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+  onResolve: PropTypes.func.isRequired,
+  onShowLocalIdentityModal: PropTypes.func.isRequired,
+}
+
+export { IdentityProvider, useIdentity }

--- a/apps/allocations/app/components/LocalIdentityBadge/LocalIdentityBadge.js
+++ b/apps/allocations/app/components/LocalIdentityBadge/LocalIdentityBadge.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import { useNetwork } from '@aragon/api-react'
+import { IdentityBadge } from '@aragon/ui'
+import { useIdentity } from './IdentityManager'
+import LocalLabelPopoverTitle from './LocalLabelPopoverTitle'
+import LocalLabelPopoverActionLabel from './LocalLabelPopoverActionLabel'
+
+const LocalIdentityBadge = ({ entity, ...props }) => {
+  const network = useNetwork()
+  const [ label, showLocalIdentityModal ] = useIdentity(entity)
+  const handleClick = () => showLocalIdentityModal(entity)
+  return (
+    <IdentityBadge
+      label={label || ''}
+      entity={entity}
+      networkType={network && network.type}
+      popoverAction={{
+        label: <LocalLabelPopoverActionLabel hasLabel={Boolean(label)} />,
+        onClick: handleClick,
+      }}
+      popoverTitle={
+        label ? <LocalLabelPopoverTitle label={label} /> : undefined
+      }
+      {...props}
+    />
+  )
+}
+
+LocalIdentityBadge.propTypes = {
+  ...IdentityBadge.propTypes,
+}
+
+export default LocalIdentityBadge

--- a/apps/allocations/app/components/LocalIdentityBadge/LocalLabelPopoverActionLabel.js
+++ b/apps/allocations/app/components/LocalIdentityBadge/LocalLabelPopoverActionLabel.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { GU, IconLabel } from '@aragon/ui'
+
+function LocalLabelPopoverActionLabel({ hasLabel }) {
+  return (
+    <div
+      css={`
+        display: flex;
+        align-items: center;
+      `}
+    >
+      <IconLabel
+        css={`
+          margin-right: ${1 * GU}px;
+        `}
+      />
+      {hasLabel ? 'Edit' : 'Add'} custom label
+    </div>
+  )
+}
+LocalLabelPopoverActionLabel.propTypes = {
+  hasLabel: PropTypes.bool,
+}
+
+export default LocalLabelPopoverActionLabel

--- a/apps/allocations/app/components/LocalIdentityBadge/LocalLabelPopoverTitle.js
+++ b/apps/allocations/app/components/LocalIdentityBadge/LocalLabelPopoverTitle.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { GU, Tag } from '@aragon/ui'
+
+function LocalLabelPopoverTitle({ label }) {
+  return (
+    <div
+      css={`
+        display: grid;
+        align-items: center;
+        grid-template-columns: auto 1fr;
+      `}
+    >
+      <span
+        css={`
+          display: inline-block;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        `}
+      >
+        {label}
+      </span>
+      <Tag
+        mode="identifier"
+        css={`
+          margin-left: ${2 * GU}px;
+        `}
+      >
+        Custom label
+      </Tag>
+    </div>
+  )
+}
+LocalLabelPopoverTitle.propTypes = {
+  label: PropTypes.string.isRequired,
+}
+
+export default LocalLabelPopoverTitle


### PR DESCRIPTION
Fixes #1375 

![Screenshot from 2019-10-21 23-05-06](https://user-images.githubusercontent.com/16065447/67258845-2b2a4280-f458-11e9-9d2b-2f7978f280b0.png)


I'm copying the LocalIdentityBadge component from Address Book, since Projects and Dot Voting are using an older version of it, which is in `shared`. I'll create a new issue to update that.

--

Fixes #1380 

Now passing the `networkType` to LocalIdentityBadge in order to choose the right network for the address' URL in Etherscan

![Screenshot from 2019-10-22 00-36-04](https://user-images.githubusercontent.com/16065447/67260977-f8864700-f463-11e9-9214-27630a0316a3.png)
(when on the private network, the etherscan link is rightfully disabled)