### PR TITLE
Fix calculateMonthlyAvg for empty reward

### DIFF
--- a/apps/rewards/app/utils/metric-utils.js
+++ b/apps/rewards/app/utils/metric-utils.js
@@ -25,6 +25,9 @@ const calculateAvgClaim = ({ claimsByToken, totalClaimsMade }, balances, convert
 }
 
 const calculateMonthlyAvg = (rewards, balances, convertRates) => {
+  if(rewards.length === 0) {
+    return 0
+  }
   let monthCount = Math.ceil((rewards.reduce((minDate, reward) => {
     return reward.endDate < minDate.endDate ? reward: minDate
   }, rewards[0]).endDate - Date.now())/ MILLISECONDS_IN_A_MONTH)


### PR DESCRIPTION
resolves #1393 

Just added a check to see if rewards are empty.