### PR TITLE
Added CurrencyBox to NewBudget.js

### DIFF
--- a/apps/allocations/app/components/Form/Field/CurrencyBox.js
+++ b/apps/allocations/app/components/Form/Field/CurrencyBox.js
@@ -1,0 +1,14 @@
+import styled from 'styled-components'
+
+const CurrencyBox = styled.div`
+  border: 1px solid #dde4e9;
+  border-left-style: none;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  padding: 8px 14px 7px;
+  font-weight: normal;
+  border-radius: 0 4px 4px 0;
+`
+
+export default CurrencyBox

--- a/apps/allocations/app/components/Panel/NewAllocation.js
+++ b/apps/allocations/app/components/Panel/NewAllocation.js
@@ -9,6 +9,7 @@ import { RecipientsInput } from '../../../../../shared/ui'
 import { MIN_AMOUNT } from '../../utils/constants'
 import { displayCurrency, isStringEmpty } from '../../utils/helpers'
 import { DescriptionInput, Form, FormField } from '../Form'
+import CurrencyBox from '../Form/Field/CurrencyBox'
 
 const INITIAL_STATE = {
   budgetValue: {},
@@ -302,17 +303,6 @@ ErrorMessage.propTypes = {
 
 const InputGroup = styled.div`
   display: flex;
-`
-
-const CurrencyBox = styled.div`
-  border: 1px solid #dde4e9;
-  border-left-style: none;
-  height: 40px;
-  display: flex;
-  align-items: center;
-  padding: 8px 14px 7px;
-  font-weight: normal;
-  border-radius: 0 4px 4px 0;
 `
 
 const ErrorText = styled.div`

--- a/apps/allocations/app/components/Panel/NewBudget.js
+++ b/apps/allocations/app/components/Panel/NewBudget.js
@@ -14,6 +14,7 @@ import { Form } from '../Form'
 import { isStringEmpty } from '../../utils/helpers'
 import { BigNumber } from 'bignumber.js'
 import { ETH_DECIMALS, MIN_AMOUNT } from '../../utils/constants'
+import CurrencyBox from '../Form/Field/CurrencyBox'
 
 // TODO:: This should be votingTokens from account?
 const INITIAL_STATE = {
@@ -128,13 +129,18 @@ class NewBudget extends React.Component {
               required
               wide
             />
-            <DropDown
-              name="token"
-              css={{ borderRadius: '0 4px 4px 0', left: '-1px' }}
-              items={symbols}
-              selected={selectedToken}
-              onChange={this.handleSelectToken}
-            />
+            {this.props.editingBudget.id ? (
+              <CurrencyBox>{symbols[selectedToken]}</CurrencyBox>
+            ) : (
+              <DropDown
+                name="token"
+                css={{ borderRadius: '0 4px 4px 0', left: '-1px' }}
+                items={symbols}
+                selected={selectedToken}
+                onChange={this.handleSelectToken}
+              />
+            )}
+
           </InputGroup>
         </Field>
       </Form>


### PR DESCRIPTION
When editing a budget, there shouldn't be a dropdown for the currency. Created a new CurrencyBox component that now gets imported by NewAllocations and NewBudget. NewBudget displays CurrencyBox instead of a Dropdown when it is in editing mode.