### PR TITLE
Projects/FundIssues: fix IssueTitle usage

### DIFF
--- a/apps/projects/app/components/Panel/FundIssues/FundIssues.js
+++ b/apps/projects/app/components/Panel/FundIssues/FundIssues.js
@@ -238,9 +238,7 @@ const FundForm = ({
                               <IconOpen />
                             )}
                           </DetailsArrow>
-                          <IssueTitle>
-                            {issue.title}
-                          </IssueTitle>
+                          <IssueTitle issue={issue} />
                         </IssueTitleBox>
                         <IssueAmountBox>
                           {issue.id in bounties &&


### PR DESCRIPTION
Missed change in #1350, where the shared IssueTitle component was imported into FundIssues, but the old interface was still being used in one spot.