### PR TITLE
Address Book: minor cleanup

### DIFF
--- a/apps/address-book/app/components/App/Entities.js
+++ b/apps/address-book/app/components/App/Entities.js
@@ -18,8 +18,15 @@ const entitiesSort = (a, b) => a.data.name.toUpperCase() > b.data.name.toUpperCa
 const Entities = ({ entities, onRemoveEntity }) => {
   const theme = useTheme()
   const ENTITY_TYPES = [
-    { name: 'Individual', fg: theme.tagIdentifierContent, bg: theme.tagIdentifier },
-    { name: 'Organization', fg: theme.warningSurfaceContent, bg: theme.warningSurface },
+    {
+      name: 'Individual',
+      fg: theme.tagIdentifierContent.toString(),
+      bg: theme.tagIdentifier.toString(),
+    },
+    { name: 'Organization',
+      fg: theme.warningSurfaceContent.toString(),
+      bg: theme.warningSurface.toString(),
+    },
   ]
   const removeEntity = address => () => onRemoveEntity(address)
 
@@ -34,33 +41,25 @@ const Entities = ({ entities, onRemoveEntity }) => {
       }
 
       renderEntry={([ name, entryAddress, entryType ]) => {
-        const typeRow = ENTITY_TYPES.filter(row => row.name === entryType)[0]
-        const values = [
-          <Text
-            key={entryAddress}
-            size="large"
-          >
-            {name}
-          </Text>,
+        const type = ENTITY_TYPES.find(t => t.name === entryType)
+        return [
+          <Text key="1" size="large">{name}</Text>,
           <LocalIdentityBadge
-            key={entryAddress}
             entity={entryAddress}
-            shorten={true}
             forceAddress
+            key="2"
+            shorten
           />,
           <Tag
-            style={{
-              fontWeight: 1000
-            }}
-            key={entryAddress}
+            background={type.bg}
+            css="font-weight: bold"
+            foreground={type.fg}
+            key="3"
             mode="identifier"
-            color={typeRow.fg}
-            background={typeRow.bg}
           >
-            {typeRow.name}
+            {type.name}
           </Tag>
         ]
-        return values
       }}
 
       renderEntryActions={([ , entryAddress ]) => (

--- a/shared/identity/LocalIdentityBadge.js
+++ b/shared/identity/LocalIdentityBadge.js
@@ -65,7 +65,7 @@ const LocalIdentityBadge = ({ entity, forceAddress, ...props }) => {
 
 LocalIdentityBadge.propTypes = {
   entity: PropTypes.string.isRequired,
-	forceAddress: PropTypes.bool
+  forceAddress: PropTypes.bool
 }
 
 const Wrap = styled.div`


### PR DESCRIPTION
I noticed [some][1] [minor][2] code style issues in Address Book that I wanted to clean up.

* replace tab with spaces
* get rid of superfluous `={true}`
* simplify variable names
* get rid of intermediate variable
* alphabetize props
* fix "invalid prop type: expected string, got object" error thrown by `Tag`
* change keys to simple numbers – it turns out aragonUI does not require keys at all here, but our linter does. In any case, having all the keys be the same value is not what we want.

  [1]: https://github.com/AutarkLabs/open-enterprise/pull/1274#pullrequestreview-305441192
  [2]: https://github.com/AutarkLabs/open-enterprise/pull/1418#pullrequestreview-306026325
