### PR TITLE
Update @aragon/api to latest

### DIFF
--- a/apps/address-book/package.json
+++ b/apps/address-book/package.json
@@ -30,7 +30,7 @@
     "test": "cross-env TRUFFLE_TEST=true npm run ganache-cli:test"
   },
   "dependencies": {
-    "@aragon/api": "AutarkLabs/aragon-api",
+    "@aragon/api": "2.0.0-beta.8",
     "@aragon/api-react": "2.0.0-beta.6",
     "@aragon/ui": "^1.0.0-alpha.26",
     "axios": "^0.18.0",

--- a/apps/allocations/package.json
+++ b/apps/allocations/package.json
@@ -30,7 +30,7 @@
     "test": "cross-env TRUFFLE_TEST=true npm run ganache-cli:test"
   },
   "dependencies": {
-    "@aragon/api": "AutarkLabs/aragon-api",
+    "@aragon/api": "2.0.0-beta.8",
     "@aragon/api-react": "2.0.0-beta.6",
     "@aragon/apps-vault": "4.1.0",
     "@aragon/os": "4.2.0",

--- a/apps/discussions/package.json
+++ b/apps/discussions/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "dependencies": {
-    "@aragon/api": "AutarkLabs/aragon-api",
+    "@aragon/api": "2.0.0-beta.8",
     "@aragon/api-react": "2.0.0-beta.6",
     "@aragon/ui": "1.0.0-alpha.11",
     "@babel/polyfill": "^7.2.5",

--- a/apps/dot-voting/package.json
+++ b/apps/dot-voting/package.json
@@ -30,7 +30,7 @@
     "test": "cross-env TRUFFLE_TEST=true npm run ganache-cli:test"
   },
   "dependencies": {
-    "@aragon/api": "AutarkLabs/aragon-api",
+    "@aragon/api": "2.0.0-beta.8",
     "@aragon/api-react": "2.0.0-beta.6",
     "@aragon/apps-shared-minime": "1.0.1",
     "@aragon/os": "4.2.0",

--- a/apps/projects/app/App.js
+++ b/apps/projects/app/App.js
@@ -74,14 +74,14 @@ const App = () => {
       try {
         const token = await getToken(code)
         setGithubLoading(false)
-        api.trigger(REQUESTED_GITHUB_TOKEN_SUCCESS, {
+        api.emitTrigger(REQUESTED_GITHUB_TOKEN_SUCCESS, {
           status: STATUS.AUTHENTICATED,
           token
         })
 
       } catch (err) {
         setGithubLoading(false)
-        api.trigger(REQUESTED_GITHUB_TOKEN_FAILURE, {
+        api.emitTrigger(REQUESTED_GITHUB_TOKEN_FAILURE, {
           status: STATUS.FAILED,
           token: null,
         })

--- a/apps/projects/app/components/Content/Settings.js
+++ b/apps/projects/app/components/Content/Settings.js
@@ -353,7 +353,7 @@ const Settings = ({ onLogin }) => {
   }
 
   const handleLogout = () => {
-    api.trigger(REQUESTED_GITHUB_DISCONNECT, {
+    api.emitTrigger(REQUESTED_GITHUB_DISCONNECT, {
       status: STATUS.INITIAL,
       token: null,
     })

--- a/apps/projects/package.json
+++ b/apps/projects/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@apollo/react-hooks": "^3.1.3",
-    "@aragon/api": "AutarkLabs/aragon-api",
+    "@aragon/api": "2.0.0-beta.8",
     "@aragon/api-react": "2.0.0-beta.6",
     "@aragon/apps-shared-minime": "1.0.1",
     "@aragon/apps-vault": "4.1.0",

--- a/apps/rewards/app/components/App/App.js
+++ b/apps/rewards/app/components/App/App.js
@@ -115,7 +115,7 @@ class App extends React.Component {
   }, CONVERT_THROTTLE_TIME)
 
   updateRewards = async () => {
-    this.props.api && this.props.api.trigger('RefreshRewards', {
+    this.props.api && this.props.api.emitTrigger('RefreshRewards', {
       userAddress: this.props.connectedAccount,
     })
   }

--- a/apps/rewards/package.json
+++ b/apps/rewards/package.json
@@ -30,7 +30,7 @@
     "test": "cross-env TRUFFLE_TEST=true npm run ganache-cli:test"
   },
   "dependencies": {
-    "@aragon/api": "AutarkLabs/aragon-api",
+    "@aragon/api": "2.0.0-beta.8",
     "@aragon/api-react": "2.0.0-beta.6",
     "@aragon/ui": "1.0.0-alpha.19",
     "@aragon/apps-shared-minime": "1.0.1",


### PR DESCRIPTION
This version has the official version of frontend triggers, which has a slightly different interface (`emitTrigger` rather than `trigger`)

This also relies on the latest version of the `master` branch of `aragon/aragon`, which uses an updated version of `@aragon/wrapper`.