### PR TITLE
Rewards: dates can't be today

### DIFF
--- a/apps/rewards/app/components/Panel/NewReward/NewReward.js
+++ b/apps/rewards/app/components/Panel/NewReward/NewReward.js
@@ -40,6 +40,9 @@ import tokenTransferAbi from '../../../../../shared/json-abis/token-transferable
 
 const tokenAbi = [].concat(tokenBalanceOfAbi, tokenBalanceOfAtAbi, tokenCreationBlockAbi, tokenSymbolAbi)
 
+const tomorrow = new Date()
+tomorrow.setDate(tomorrow.getDate() + 1)
+
 const INITIAL_STATE = {
   description: '',
   referenceAsset: null,
@@ -55,12 +58,12 @@ const INITIAL_STATE = {
     balance: '',
     symbol: '',
   },
-  dateReference: new Date(),
-  dateStart: new Date(),
-  dateEnd: new Date(),
+  dateReference: tomorrow,
+  dateStart: tomorrow,
+  dateEnd: tomorrow,
   disbursement: '',
   disbursementUnit: MONTHS,
-  disbursements: [new Date()],
+  disbursements: [tomorrow],
   draftSubmitted: false,
   semanticErrors: [],
   warnings: [],
@@ -178,16 +181,15 @@ class NewRewardClass extends React.Component {
       semanticErrors.push('meritTokenTransferable')
     if (toWei(state.amount) > +state.amountToken.amount)
       semanticErrors.push('amountOverBalance')
-    const today = moment()
     if (state.rewardType === ONE_TIME_DIVIDEND &&
-        moment(state.dateReference).isBefore(today, 'day'))
+        moment(state.dateReference).isBefore(tomorrow, 'day'))
       semanticErrors.push('dateReferencePassed')
     if (state.rewardType === RECURRING_DIVIDEND ||
         state.rewardType === ONE_TIME_MERIT) {
       const start = moment(state.dateStart), end = moment(state.dateEnd)
-      if (start.isBefore(today, 'day'))
+      if (start.isBefore(tomorrow, 'day'))
         semanticErrors.push('dateStartPassed')
-      if (end.isBefore(today, 'day'))
+      if (end.isBefore(tomorrow, 'day'))
         semanticErrors.push('dateEndPassed')
       if (start.isAfter(end, 'day'))
         semanticErrors.push('dateStartAfterEnd')


### PR DESCRIPTION
Restrict the dates in the New Reward side panel so that they have to be at least tomorrow. Change the default dates to tomorrow.

Since we're not using the `moment` library anymore, I didn't introduce new usages of it. However, I also didn't change the already existing usages in order to deliver this quickly.

Before: the default date was today and it was allowed
After:
![Screenshot from 2019-10-25 12-39-39](https://user-images.githubusercontent.com/16065447/67592137-91e38080-f724-11e9-8479-125368fd5821.png)

**Note**: there was no need to change the error messages since they already restricted the dates to after today.