### PR TITLE
Dot Voting: fix stubbedApi logic

### DIFF
--- a/apps/dot-voting/app/api-react.js
+++ b/apps/dot-voting/app/api-react.js
@@ -1,3 +1,4 @@
+import { Observable } from 'rxjs'
 import buildStubbedApiReact from '../../../shared/api-react'
 import { ETHER_TOKEN_FAKE_ADDRESS } from './utils/token-utils'
 
@@ -20,10 +21,16 @@ const functions = process.env.NODE_ENV !== 'production' && ((appState, setAppSta
     votes: [
       ...appState.votes,
       {
-        voteId: appState.votes.length + 1,
+        voteId: String(appState.votes.length + 1),
         data: {
           balance: 10e18,
           creator: '0xb4124cEB3451635DAcedd11767f004d8a28c6eE7',
+          executionTargetData: {
+            address: '0x3d9f32b8bc14167dacbc895d78c9acaae979e554',
+            iconSrc: 'https://ipfs.eth.aragon.network/ipfs/QmRsGHLj3mLPmY3Niohh5LqqawPh2GHzgdKoWsy3uztQwC/meta/icon.svg',
+            identifier: 'allocations',
+            name: 'Allocations',
+          },
           metadata: description,
           minAcceptQuorum: 0,
           options: [{
@@ -43,6 +50,29 @@ const functions = process.env.NODE_ENV !== 'production' && ((appState, setAppSta
       }
     ]
   }),
+  call: (fn, ...args) => {
+    switch (fn) {
+    case 'getVoterState': {
+      // const [ voteId, connectedAccount ] = args
+      return new Observable(subscriber => {
+        // TODO: return connectedAccount's votes for voteId
+        subscriber.next([])
+        subscriber.complete()
+      })
+    }
+    case 'canVote': {
+      return new Observable(subscriber => {
+        subscriber.next(true)
+        subscriber.complete()
+      })
+    }
+    default:
+      throw new Error(
+        `Dot Voting is stubbing 'call', but 'call(${fn}, ${
+          args.join(', ')})' is not yet stubbed!`
+      )
+    }
+  }
 }))
 
 const { AragonApi, useAragonApi, useNetwork } = buildStubbedApiReact({ initialState, functions })

--- a/apps/dot-voting/app/components/LocalIdentityBadge/LocalIdentityBadge.js
+++ b/apps/dot-voting/app/components/LocalIdentityBadge/LocalIdentityBadge.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useNetwork } from '@aragon/api-react'
+import { useNetwork } from '../../api-react'
 import { IdentityBadge } from '@aragon/ui'
 import { useIdentity } from './IdentityManager'
 import LocalLabelPopoverTitle from './LocalLabelPopoverTitle'

--- a/apps/dot-voting/app/components/LocalIdentityBadge/LocalLabelAppBadge.js
+++ b/apps/dot-voting/app/components/LocalIdentityBadge/LocalLabelAppBadge.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useNetwork } from '@aragon/api-react'
+import { useNetwork } from '../../api-react'
 import { AppBadge } from '@aragon/ui'
 import { useIdentity } from './IdentityManager'
 import LocalLabelPopoverTitle from './LocalLabelPopoverTitle'

--- a/apps/dot-voting/app/components/VoteDetails/Participation.js
+++ b/apps/dot-voting/app/components/VoteDetails/Participation.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Spring, config as springs } from 'react-spring'
-import { useAragonApi } from '@aragon/api-react'
+import { useAragonApi } from '../../api-react'
 import { Box, Text, useTheme } from '@aragon/ui'
 import VotingOption from '../VotingOption'
 

--- a/apps/dot-voting/app/components/VoteDetails/VotingResults.js
+++ b/apps/dot-voting/app/components/VoteDetails/VotingResults.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
-import { useAragonApi } from '@aragon/api-react'
+import { useAragonApi } from '../../api-react'
 import { useTheme } from '@aragon/ui'
 import { getVoteStatus } from '../../utils/vote-utils'
 import { VOTE_STATUS_SUCCESSFUL } from '../../utils/vote-types'

--- a/apps/dot-voting/app/components/VoteStatus.js
+++ b/apps/dot-voting/app/components/VoteStatus.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { useAragonApi } from '@aragon/api-react'
+import { useAragonApi } from '../api-react'
 import { IconCheck, IconCross, IconTime, useTheme } from '@aragon/ui'
 import {
   VOTE_STATUS_EXECUTED,

--- a/shared/api-react/useStubbedApi.js
+++ b/shared/api-react/useStubbedApi.js
@@ -49,6 +49,10 @@ const buildHook = ({ initialState, functions }) => {
       getCache: key => {
         return appState[key]
       },
+      resolveAddressIdentity: address => new Observable(subscriber => {
+        subscriber.next(`STUBBED-${address}`)
+        subscriber.complete()
+      }),
       ...functions(appState, db.setData),
     }
 


### PR DESCRIPTION
* add executionTargetData, required since #1326 
* return string for `voteId`, to satisfy `propTypes` expectations
* add resolveAddressIdentity to shared/api-react
* handle some uses of `call`, the lack of which caused noisy warnings
* update imports from `@aragon/api-react` to local stub, which resolves more warnings