### PR TITLE
Rewards: AragonUI version bump

### DIFF
--- a/apps/rewards/package.json
+++ b/apps/rewards/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@aragon/api": "2.0.0-beta.8",
     "@aragon/api-react": "2.0.0-beta.6",
-    "@aragon/ui": "1.0.0-alpha.19",
+    "@aragon/ui": "1.0.0-alpha.32",
     "@aragon/apps-shared-minime": "1.0.1",
     "@aragon/apps-vault": "4.1.0",
     "@aragon/os": "4.2.0",


### PR DESCRIPTION
A version bump of Rewards' AragonUI in order to implement help bubbles in the New Reward side panel according to the design. In reference to #1466.

The version bump seems to cause no issues. I tested everything according to the Test Script, except claiming rewards, which didn't show up as an option.

![Screenshot from 2019-10-28 10-58-22](https://user-images.githubusercontent.com/16065447/67699913-f1d36480-f97a-11e9-91c8-e07d70fd25ba.png)
