### PR TITLE
Rewards: Recurring Dividends fixes

### DIFF
--- a/apps/rewards/app/app-state-reducer.js
+++ b/apps/rewards/app/app-state-reducer.js
@@ -22,13 +22,15 @@ function appStateReducer(state) {
     state.rewards = state.rewards  || []
     state.claims = state.claims  || []
     state.rewards = state.rewards === [] ? [] : state.rewards.reduce((rewards, reward) => {
-      const currentReward = rewards.find(filteredElement => {
+      const currentReward = reward.isMerit ? undefined : rewards.find(filteredElement => {
         return filteredElement.description === reward.description && parseInt(filteredElement.rewardId, 10) + filteredElement.occurances === parseInt(reward.rewardId)
       })
       if(currentReward !== undefined){
         currentReward.occurances += 1
         currentReward.rewardType = RECURRING_DIVIDEND
+        currentReward.disbursementBlocks.push(reward.endBlock)
         currentReward.disbursements.push(new Date(reward.endDate))
+        currentReward.claims = (currentReward.claims || !!currentReward.claimed) + !!parseInt(reward.timeClaimed, 10)
         const durationInBlocks = currentReward.duration*15000
         if (durationInBlocks % MILLISECONDS_IN_A_YEAR ===0) {
           currentReward.disbursementUnit = YEARS
@@ -45,7 +47,9 @@ function appStateReducer(state) {
         }
       } else {
         reward.occurances = 1
+        reward.claims = 0 + !!reward.claimed
         reward.disbursements = [new Date(reward.endDate)]
+        reward.disbursementBlocks = [reward.endBlock]
         reward.claimed = reward.timeClaimed !== '0'
         if(reward.isMerit){
           reward.rewardType = ONE_TIME_MERIT

--- a/apps/rewards/app/components/App/App.js
+++ b/apps/rewards/app/components/App/App.js
@@ -173,23 +173,21 @@ class App extends React.Component {
       reward.isMerit = false
     }
     if (reward.rewardType === RECURRING_DIVIDEND) {
+      reward.occurances = reward.disbursements.length
       switch (reward.disbursementUnit) {
       case 'Days':
-        reward.occurances = millisecondsToDays(reward.dateStart, reward.dateEnd)
         reward.duration = millisecondsToBlocks(Date.now(), MILLISECONDS_IN_A_DAY + Date.now())
         break
       case 'Weeks':
-        reward.occurances = millisecondsToWeeks(reward.dateStart, reward.dateEnd)
         reward.duration = millisecondsToBlocks(Date.now(), MILLISECONDS_IN_A_WEEK + Date.now())
         break
       case 'Years':
-        reward.occurances = millisecondsToYears(reward.dateStart, reward.dateEnd)
         reward.duration = millisecondsToBlocks(Date.now(), MILLISECONDS_IN_A_YEAR + Date.now())
         break
       default: // Monthly
-        reward.occurances = millisecondsToMonths(reward.dateStart, reward.dateEnd)
         reward.duration = millisecondsToBlocks(Date.now(), MILLISECONDS_IN_A_MONTH + Date.now())
       }
+      startBlock -= reward.duration
     }
     if(reward.rewardType === ONE_TIME_DIVIDEND){
       startBlock = currentBlock
@@ -236,7 +234,7 @@ class App extends React.Component {
 
   claimReward = reward => {
     // TODO
-    this.props.api.claimReward(reward.rewardId).toPromise()
+    this.props.api.claimReward(reward.rewardId + reward.claims).toPromise()
   }
 
   openDetailsView = reward => {

--- a/apps/rewards/app/components/Content/MyRewards.js
+++ b/apps/rewards/app/components/Content/MyRewards.js
@@ -44,7 +44,7 @@ const MyRewards = ({
         }}/>
         View
       </StyledContextMenuItem>
-      {(!reward.claimed && (reward.endDate < Date.now())) && (
+      {(reward.claims < reward.disbursements.length && (reward.disbursements[reward.claims] < Date.now())) && (
         <StyledContextMenuItem
           onClick={() => claimReward(reward)}
         >
@@ -118,7 +118,9 @@ const renderRecurringDividend = (reward, amountTokens) => {
     userRewardAmount,
     amountToken,
     endDate,
-    timeClaimed
+    timeClaimed,
+    claims,
+    disbursements
   } = reward
   const decimals = amountTokens.find(t => t.symbol === amountToken).decimals
   const displayAmount = (
@@ -126,8 +128,8 @@ const renderRecurringDividend = (reward, amountTokens) => {
       +{displayCurrency(BigNumber(userRewardAmount), decimals)} {amountToken}
     </Text>
   )
-  const disbursementDate = (new Date(endDate)).toDateString()
-  const status = timeClaimed > 0 ? 'Claimed' : (Date.now() > endDate ? 'Ready to claim' : 'Pending')
+  const disbursementDate = (disbursements[claims] || disbursements[claims-1]).toDateString()
+  const status = claims === disbursements.length ? 'Claimed' : (Date.now() > disbursements[claims].getTime() ? 'Ready to claim' : 'Pending')
   return [ description, disbursementDate, status, displayAmount ]
 }
 


### PR DESCRIPTION
- resolves #1429 
- start date now corresponds to the first disbursement date
- simplified date calculations for new reward submissions
- made recurring reward claiming logic more robust so you can claim multiple recurring rewards from a single row