### PR TITLE
Pushed version of Aragon UI to the latest .32

### DIFF
--- a/apps/projects/package.json
+++ b/apps/projects/package.json
@@ -38,7 +38,7 @@
     "@aragon/apps-shared-minime": "1.0.1",
     "@aragon/apps-vault": "4.1.0",
     "@aragon/os": "4.2.0",
-    "@aragon/ui": "1.0.0-alpha.19",
+    "@aragon/ui": "1.0.0-alpha.32",
     "@babel/polyfill": "^7.2.5",
     "@babel/runtime": "^7.6.0",
     "apollo-boost": "^0.1.22",


### PR DESCRIPTION
Seems to be working well enough, and it's useful to a) use the same version across all of our apps, and  b) follow the latest version - this is alpha, each patch level closer to final release.