### PR TITLE
Dot Voting: allow voting with number input

### DIFF
--- a/apps/dot-voting/app/components/VoteDetails/CastVote/CastVote.js
+++ b/apps/dot-voting/app/components/VoteDetails/CastVote/CastVote.js
@@ -40,7 +40,7 @@ const CastVote = ({ onVote, toggleVotingMode, vote, voteWeights, votingPower }) 
   }, [ vote.voteId, onVote, votingPower, voteAmounts ])
 
   return (
-    <div css="width: 100%">
+    <form onSubmit={handleVoteSubmit} css="width: 100%">
       <div css="display: flex; justify-content: space-between">
         <Label>Your vote</Label>
         <Label>Percentage</Label>
@@ -65,19 +65,19 @@ const CastVote = ({ onVote, toggleVotingMode, vote, voteWeights, votingPower }) 
       </Text.Block>
 
       <div css="display: flex; justify-content: flex-end; align-items: center; width: 100%">
-        <Button onClick={toggleVotingMode}>
+        <Button type="button" onClick={toggleVotingMode}>
           Cancel
         </Button>
         <Button
           css="margin: 1rem 0 1rem 0.5rem"
           mode="strong"
-          onClick={handleVoteSubmit}
+          type="submit"
           disabled={remaining === 100}
         >
           Submit Vote
         </Button>
       </div>
-    </div>
+    </form>
   )
 }
 

--- a/apps/dot-voting/app/components/VoteDetails/CastVote/CastVote.js
+++ b/apps/dot-voting/app/components/VoteDetails/CastVote/CastVote.js
@@ -1,28 +1,9 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
 import { Button, Text, useTheme } from '@aragon/ui'
-import Slider from '../Slider'
-import Label from './Label'
-import LocalIdentityBadge from '../LocalIdentityBadge/LocalIdentityBadge'
+import Label from '../Label'
 import { BN } from 'web3-utils'
-
-const ValueContainer = styled.div`
-  box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.03);
-  border-radius: 3px;
-  width: 69px;
-  height: 40px;
-  border: 1px solid ${({ theme }) => theme.surfaceIcon};
-  padding-top: 0.5rem;
-  text-align: center;
-`
-
-const SliderAndValueContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 100%;
-`
+import EditVoteOption from './EditVoteOption'
 
 const CastVote = ({ onVote, toggleVotingMode, vote, voteWeights, votingPower }) => {
   const theme = useTheme()
@@ -53,7 +34,7 @@ const CastVote = ({ onVote, toggleVotingMode, vote, voteWeights, votingPower }) 
         return (
           acc +
           (idx === index
-            ? Math.round(value * 100) || 0
+            ? Math.round(value) || 0
             : trueValue || 0)
         )
       },
@@ -62,7 +43,7 @@ const CastVote = ({ onVote, toggleVotingMode, vote, voteWeights, votingPower }) 
 
     if (total <= 100) {
       voteOptions[idx].sliderValue = value
-      voteOptions[idx].trueValue = Math.round(value * 100)
+      voteOptions[idx].trueValue = Math.round(value)
       setRemaining(100 - total)
       setVoteOptions([...voteOptions])
     }
@@ -86,33 +67,13 @@ const CastVote = ({ onVote, toggleVotingMode, vote, voteWeights, votingPower }) 
       </div>
 
       {voteOptions.map((option, index) => (
-        <div key={index}>
-          <SliderAndValueContainer>
-            <div style={{ width: '100%' }}>
-              <LocalIdentityBadge
-                compact
-                fontSize="small"
-                key={vote.data.options[index].label}
-                entity={vote.data.options[index].label}
-                shorten
-              />
-            </div>
-            <div css={`
-              display: flex;
-              margin: 0.5rem 0 1rem 0;
-              justify-content: space-between;
-              width: 100%;
-            `}>
-              <Slider
-                value={option.sliderValue}
-                onUpdate={value => sliderUpdate(value, index)}
-              />
-              <ValueContainer theme={theme}>
-                {option.trueValue || 0}
-              </ValueContainer>
-            </div>
-          </SliderAndValueContainer>
-        </div>
+        <EditVoteOption
+          key={index}
+          onUpdate={sliderUpdate}
+          option={option}
+          optionIndex={index}
+          vote={vote}
+        />
       ))}
 
       <Text.Block

--- a/apps/dot-voting/app/components/VoteDetails/CastVote/EditVoteOption.js
+++ b/apps/dot-voting/app/components/VoteDetails/CastVote/EditVoteOption.js
@@ -1,0 +1,88 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { TextInput as AragonTextInput, useTheme } from '@aragon/ui'
+import Slider from '../../Slider'
+import LocalIdentityBadge from '../../LocalIdentityBadge/LocalIdentityBadge'
+
+const Label = styled.div`
+  width: 100%;
+`
+
+const Inputs = styled.div`
+  display: flex;
+  margin: 0.5rem 0 1rem 0;
+  justify-content: space-between;
+  width: 100%;
+`
+
+const TextInput = styled(AragonTextInput).attrs({
+  inputMode: 'numeric',
+  pattern: '[0-9]*',
+})`
+  border-radius: 3px;
+  border: 1px solid ${({ theme }) => theme.surfaceIcon};
+  box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.03);
+  height: 40px;
+  text-align: center;
+  width: 69px;
+  ::-webkit-inner-spin-button,
+  ::-webkit-outer-spin-button {
+    appearance: none;
+    margin: 0;
+  }
+`
+
+const Wrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+`
+
+const EditVoteOption = ({
+  onUpdate,
+  option,
+  optionIndex,
+  vote,
+}) => {
+  const theme = useTheme()
+  return (
+    <Wrap>
+      <Label>
+        <LocalIdentityBadge
+          compact
+          entity={vote.data.options[optionIndex].label}
+          fontSize="small"
+          shorten
+        />
+      </Label>
+      <Inputs>
+        <Slider
+          onUpdate={value => onUpdate(value * 100, optionIndex)}
+          value={(option.sliderValue || 0) / 100}
+        />
+        <TextInput
+          type="number"
+          theme={theme}
+          value={option.trueValue || 0}
+          onChange={e => {
+            onUpdate(parseInt(e.target.value, 10), optionIndex)
+          }}
+        />
+      </Inputs>
+    </Wrap>
+  )
+}
+
+EditVoteOption.propTypes = {
+  onUpdate: PropTypes.func.isRequired,
+  option: PropTypes.shape({
+    sliderValue: PropTypes.number,
+    trueValue: PropTypes.number,
+  }).isRequired,
+  optionIndex: PropTypes.number.isRequired,
+  vote: PropTypes.object.isRequired,
+}
+
+export default EditVoteOption

--- a/apps/dot-voting/app/components/VoteDetails/CastVote/EditVoteOption.js
+++ b/apps/dot-voting/app/components/VoteDetails/CastVote/EditVoteOption.js
@@ -41,10 +41,9 @@ const Wrap = styled.div`
 `
 
 const EditVoteOption = ({
+  label,
   onUpdate,
-  option,
-  optionIndex,
-  vote,
+  value,
 }) => {
   const theme = useTheme()
   return (
@@ -52,22 +51,22 @@ const EditVoteOption = ({
       <Label>
         <LocalIdentityBadge
           compact
-          entity={vote.data.options[optionIndex].label}
+          entity={label}
           fontSize="small"
           shorten
         />
       </Label>
       <Inputs>
         <Slider
-          onUpdate={value => onUpdate(value * 100, optionIndex)}
-          value={(option.sliderValue || 0) / 100}
+          onUpdate={value => onUpdate(value * 100)}
+          value={value / 100}
         />
         <TextInput
           type="number"
           theme={theme}
-          value={option.trueValue || 0}
+          value={value}
           onChange={e => {
-            onUpdate(parseInt(e.target.value, 10), optionIndex)
+            onUpdate(parseInt(e.target.value, 10))
           }}
         />
       </Inputs>
@@ -77,12 +76,8 @@ const EditVoteOption = ({
 
 EditVoteOption.propTypes = {
   onUpdate: PropTypes.func.isRequired,
-  option: PropTypes.shape({
-    sliderValue: PropTypes.number,
-    trueValue: PropTypes.number,
-  }).isRequired,
-  optionIndex: PropTypes.number.isRequired,
-  vote: PropTypes.object.isRequired,
+  label: PropTypes.string.isRequired,
+  value: PropTypes.number.isRequired,
 }
 
 export default EditVoteOption

--- a/apps/dot-voting/app/components/VoteDetails/CastVote/index.js
+++ b/apps/dot-voting/app/components/VoteDetails/CastVote/index.js
@@ -1,0 +1,3 @@
+import CastVote from './CastVote'
+
+export default CastVote


### PR DESCRIPTION
Rather than only showing the vote value in a grey box that looks like an input field, this uses an actual input field. The amounts can be edited from either the numeric input or the slider.

<img alt="slide or type" src="https://user-images.githubusercontent.com/221614/67864588-39cdc500-fafc-11e9-8039-738451e40315.gif" width="350px">


## TODO

- [x] Wait for #1472 merge; retarget this one at `dev`