### PR TITLE
Projects: limit filter counts to what's downloaded

### DIFF
--- a/apps/projects/app/components/Content/Issues.js
+++ b/apps/projects/app/components/Content/Issues.js
@@ -340,7 +340,7 @@ class Issues extends React.PureComponent {
               .map(issue => (
                 <Issue
                   isSelected={issue.id in this.state.selectedIssues}
-                  key={issue.number}
+                  key={issue.id}
                   {...issue}
                   onClick={this.props.setSelectedIssue}
                   onSelect={this.handleIssueSelection}

--- a/apps/projects/app/components/Panel/FundIssues/FundIssues.js
+++ b/apps/projects/app/components/Panel/FundIssues/FundIssues.js
@@ -488,6 +488,7 @@ const FundIssues = ({ issues, mode }) => {
         fundingHistory: bounties[issues[key].id].fundingHistory,
         deadline: bounties[issues[key].id].deadline,
         hours: bounties[issues[key].id].hours,
+        id: bounties[issues[key].id].id,
         size: bounties[issues[key].id].size,
         amount: bounties[issues[key].id].amount,
         token: bounties[issues[key].id].token,

--- a/apps/projects/app/components/Shared/FilterBar/prepareFilters.js
+++ b/apps/projects/app/components/Shared/FilterBar/prepareFilters.js
@@ -28,7 +28,11 @@ const prepareFilters = (issues, bountyIssues) => {
     name: BOUNTY_STATUS['not-funded'],
     count: issues.length - bountyIssues.length,
   }
-  bountyIssues.map(issue => filters.statuses[issue.data.workStatus].count++)
+  bountyIssues.map(issue => {
+    if (issues.map(i => i.id).includes(issue.data.id)) {
+      filters.statuses[issue.data.workStatus].count++
+    }
+  })
 
   issues.map(issue => {
     if (issue.milestone) {

--- a/apps/projects/app/store/helpers/issues.js
+++ b/apps/projects/app/store/helpers/issues.js
@@ -65,10 +65,11 @@ export const loadIssueData = async ({ repoId, issueNumber }) => {
 export const loadIpfsData = async ipfsHash => {
   const {
     detailsOpen,
-    exp,
     deadline,
+    exp,
     fundingHistory,
     hours,
+    id,
     key,
     repo,
     size,
@@ -81,6 +82,7 @@ export const loadIpfsData = async ipfsHash => {
     deadline,
     fundingHistory,
     hours,
+    id,
     key,
     repo,
     size,


### PR DESCRIPTION
Fixes #1488 

Don't show full count of all bounties, only show numbers that correspond to other filters