### PR TITLE
Fix app state clash on browser refresh

### DIFF
--- a/apps/address-book/app/app-state-reducer.js
+++ b/apps/address-book/app/app-state-reducer.js
@@ -1,4 +1,10 @@
-const appStateReducer = state => {
+import { getContentHolder } from '../../../shared/lib/utils'
+
+let prevState = {}
+
+const appStateReducer = currentState => {
+  const state = getContentHolder('entries', currentState, prevState)
+  prevState = { ...state }
   return {
     ...state
   }

--- a/apps/allocations/app/app-state-reducer.js
+++ b/apps/allocations/app/app-state-reducer.js
@@ -1,5 +1,6 @@
 import { BigNumber } from 'bignumber.js'
 import { ETHER_TOKEN_FAKE_ADDRESS } from '../../../shared/lib/token-utils'
+import { getContentHolder } from '../../../shared/lib/utils'
 
 // Use this function to sort by ETH and then token symbol
 const compareBalancesByEthAndSymbol = (tokenA, tokenB) => {
@@ -17,7 +18,13 @@ const getTokenFromAddress = (tokenAddress, tokenList) => {
   return tokenList.find(token => token.address === tokenAddress)
 }
 
-function appStateReducer(state) {
+let prevState = {}
+
+function appStateReducer(currentState) {
+
+  const state = getContentHolder('accounts', currentState, prevState)
+  prevState = { ...state }
+
   const { accounts: budgets, balances } = state || {}
 
   const balancesBn = balances

--- a/apps/dot-voting/app/app-state-reducer.js
+++ b/apps/dot-voting/app/app-state-reducer.js
@@ -1,4 +1,10 @@
-function appStateReducer(state) {
+import { getContentHolder } from '../../../shared/lib/utils'
+
+let prevState = {}
+
+function appStateReducer(currentState) {
+  const state = getContentHolder('votes', currentState, prevState)
+  prevState = { ...state }
   return {
     ...state,
   }

--- a/apps/projects/app/app-state-reducer.js
+++ b/apps/projects/app/app-state-reducer.js
@@ -1,4 +1,10 @@
-function appStateReducer(state) {
+import { getContentHolder } from '../../../shared/lib/utils'
+
+let prevState = {}
+
+function appStateReducer(currentState) {
+  const state = getContentHolder('repos', currentState, prevState)
+  prevState = { ...state }
   return state || {}
 }
 

--- a/apps/rewards/app/app-state-reducer.js
+++ b/apps/rewards/app/app-state-reducer.js
@@ -12,8 +12,14 @@ import {
   calculateMyRewardsSummary
 } from './utils/metric-utils'
 import { MILLISECONDS_IN_A_MONTH, MILLISECONDS_IN_A_WEEK, MILLISECONDS_IN_A_YEAR, MILLISECONDS_IN_A_DAY } from '../../../shared/ui/utils/math-utils'
+import { getContentHolder } from '../../../shared/lib/utils'
 
-function appStateReducer(state) {
+let prevState = {}
+
+function appStateReducer(currentState) {
+
+  const state = getContentHolder('rewards', currentState, prevState)
+  prevState = { ...state }
   
   if(state){
     state.amountTokens = state.balances.map(token => {

--- a/shared/lib/utils.js
+++ b/shared/lib/utils.js
@@ -28,3 +28,18 @@ export function formatTokenAmount(
     formatDecimals(round(amount / Math.pow(10, decimals), rounding), 18)
   )
 }
+
+/**
+ * Chooses between two objects depending on whether a given array property in
+ * each of them has content. If the comparison is nonconclusive, the first
+ * object (the incumbent) is returned.
+ */
+export const getContentHolder = (property, incumbent, contender) => {
+  if (incumbent && incumbent.hasOwnProperty(property)
+      && incumbent[property].length > 0)
+    return incumbent
+  if (contender && contender.hasOwnProperty(property)
+      && contender[property].length > 0)
+    return contender
+  return incumbent
+}


### PR DESCRIPTION
Fixes #1411 

When you're working with an app and you refresh the browser, the app shows as loading, then the content loads, then you see an empty card, and then you see the content again.

![Peek 2019-10-29 18-34](https://user-images.githubusercontent.com/16065447/67823138-e9b91900-fa8f-11e9-90f2-a1b3c1e4c213.gif)

In order to solve this issue, let's dig into the three ways in which an app is loaded:

**A. On first load**
   1. The app state reducer is called with a `null` state (you see an empty card)
   2. The store is initialized (you see an empty card)
   3. The app state reducer is called with a state loaded from the store (you see the actual content)

![Screenshot from 2019-10-29 18-40-01](https://user-images.githubusercontent.com/16065447/67823200-2127c580-fa90-11e9-8d8c-5a9d45e70590.png)

**B. Coming back from another application**
   1. The app state reducer is called with the cached previous state (you see the old content)
   2. The app state reducer is called with a state loaded from the store (you see the actual content)

![Screenshot from 2019-10-29 18-39-27](https://user-images.githubusercontent.com/16065447/67823199-2127c580-fa90-11e9-813e-468fe6bd2f19.png)

**C. After refreshing the browser**
   1. The app state reducer is called with a `null` state (you see an empty card)
   2. The app state reducer is called with the cached previous state (you see the old content)
   3. The store is initialized (you see an empty card)
   4. The app state reducer is called with a state loaded from the store (you see the actual content)

![Screenshot from 2019-10-29 18-38-50](https://user-images.githubusercontent.com/16065447/67823198-208f2f00-fa90-11e9-9241-e453c43520fc.png)

The issue at hand is caused by step C.3, which shouldn't take place, since the store is already initialized. I believe C.3 to be a bug from AragonAPI, which @schwartz10 already [reported](https://github.com/aragon/aragon.js/issues/396).

A downstream fix for this bug can only take place in the app state reducer, since it is called before the store. We need a way to detect that step C.3 is taking place and refrain from updating the state before it finishes loading, since the old state that we already have is more complete.

But how to detect C.3 based solely on the state? Sure, you can detect that the store is being initialized, but how can you know that it's not loading for the first time? What I came up with was to store the last state received by the app state reducer, and compare it to the current one. C.3 is the only case in which the previous state has content that the current state doesn't have.

If C.3 is happening, don't update the state; just use the previous one. And as soon as the current state is at least as complete as the previous one, update it.