### PR TITLE
Added caching and syncing to apps

### DIFF
--- a/apps/address-book/app/components/App/App.js
+++ b/apps/address-book/app/components/App/App.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 
 import { useAragonApi } from '../../api-react'
-import { Button, Header, IconPlus, Main, SidePanel } from '@aragon/ui'
+import { Button, Header, IconPlus, Main, SidePanel, SyncIndicator } from '@aragon/ui'
 
 import { IdentityProvider } from '../LocalIdentityBadge/IdentityManager'
 import { ipfsAdd } from '../../../../../shared/utils/ipfs'
@@ -15,8 +15,8 @@ const ASSETS_URL = './aragon-ui'
 const App = () => {
   const [ panelVisible, setPanelVisible ] = useState(false)
   const { api, appState = {} } = useAragonApi()
-  
-  const { entries = [] } = appState
+
+  const { entries = [], isSyncing = true } = appState
 
   const createEntity = async ({ address, name, type }) => {
     closePanel()
@@ -67,7 +67,7 @@ const App = () => {
         onShowLocalIdentityModal={handleShowLocalIdentityModal}
       >
         { entries.length === 0
-          ? <Empty action={newEntity} />
+          ? <Empty action={newEntity} isSyncing={isSyncing} />
           : (
             <React.Fragment>
               <Header
@@ -81,6 +81,7 @@ const App = () => {
                 onNewEntity={newEntity}
                 onRemoveEntity={removeEntity}
               />
+              <SyncIndicator visible={isSyncing} />
             </React.Fragment>
           )
         }

--- a/apps/address-book/app/components/Card/Empty.js
+++ b/apps/address-book/app/components/Card/Empty.js
@@ -1,15 +1,31 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { Button, EmptyStateCard, GU, unselectable } from '@aragon/ui'
+import { Button, EmptyStateCard, GU, LoadingRing, unselectable } from '@aragon/ui'
 import emptyStatePng from '../../assets/no-contacts.png'
 
 const illustration = <img src={emptyStatePng} alt="" height="160" />
 
-const Empty = ({ action }) => (
+const Empty = ({ action, isSyncing }) => (
   <EmptyWrapper>
     <EmptyStateCard
-      text="No entities here!"
+      text={
+        isSyncing ? (
+          <div
+            css={`
+              display: grid;
+              align-items: center;
+              justify-content: center;
+              grid-template-columns: auto auto;
+              grid-gap: ${1 * GU}px;
+            `}
+          >
+            <LoadingRing />
+            <span>Syncing…</span>
+          </div>
+        ) : (
+          'No entities here!'
+        )}
       illustration={illustration}
       actionText="New Entity"
       action={
@@ -21,6 +37,7 @@ const Empty = ({ action }) => (
 
 Empty.propTypes = {
   action: PropTypes.func.isRequired,
+  isSyncing: PropTypes.bool.isRequired,
 }
 
 const EmptyWrapper = styled.div`

--- a/apps/address-book/app/store/events.js
+++ b/apps/address-book/app/store/events.js
@@ -5,6 +5,12 @@ export const handleEvent = async (state, event) => {
   const { entries } = state
   let nextState = { ...state, }
   switch (eventName) {
+  case 'SYNC_STATUS_SYNCING':
+    nextState.isSyncing = true
+    break
+  case 'SYNC_STATUS_SYNCED':
+    nextState.isSyncing = false
+    break
   case 'EntryAdded':
     nextState.entries = await onEntryAdded({ entries }, returnValues)
     break

--- a/apps/address-book/app/store/init.js
+++ b/apps/address-book/app/store/init.js
@@ -5,6 +5,7 @@ export const initStore = () => {
 
   const initialState = {
     entries: [],
+    isSyncing: false,
   }
   return app.store(
     async (state, event) => {
@@ -21,6 +22,17 @@ export const initStore = () => {
       }
       // always return the state even unmodified
       return state
+    },
+    {
+      init: initState(),
     }
   )
+}
+
+const initState = () => async cachedState => {
+  const newState = {
+    ...cachedState,
+    isSyncing: true,
+  }
+  return newState
 }

--- a/apps/allocations/app/components/App/App.js
+++ b/apps/allocations/app/components/App/App.js
@@ -158,6 +158,7 @@ const App = () => {
                 onDeactivate={onDeactivate}
                 onReactivate={onReactivate}
               />
+              <SyncIndicator visible={isSyncing} />
             </React.Fragment>
           )
         }
@@ -168,7 +169,6 @@ const App = () => {
           onClose={closeModal}
           onSubmit={onSubmitDeactivate}
         />
-        <SyncIndicator visible={isSyncing} />
         <SidePanel
           title={(panel && panel.data.heading) || ''}
           opened={panelOpen}

--- a/apps/allocations/app/components/App/App.js
+++ b/apps/allocations/app/components/App/App.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { useAragonApi } from '../../api-react'
-import { Button, Header, IconPlus, Main, SidePanel } from '@aragon/ui'
+import { Button, Header, IconPlus, Main, SidePanel, SyncIndicator } from '@aragon/ui'
 
 import { IdentityProvider } from '../LocalIdentityBadge/IdentityManager'
 import { Empty } from '../Card'
@@ -14,7 +14,7 @@ const App = () => {
   const [ isModalVisible, setModalVisible ] = useState(false)
   const [ currentBudgetId, setCurrentBudgetId ] = useState('')
   const { api, appState } = useAragonApi()
-  const { allocations = [], budgets = [] } = appState
+  const { allocations = [], budgets = [], isSyncing = true } = appState
 
   const saveBudget = ({ id, amount, name, token }) => {
     if (id) {
@@ -137,7 +137,7 @@ const App = () => {
         onShowLocalIdentityModal={handleShowLocalIdentityModal}
       >
         {budgets.length === 0
-          ? <Empty action={onNewBudget} />
+          ? <Empty action={onNewBudget} isSyncing={isSyncing} />
           : (
             <React.Fragment>
               <Header
@@ -168,6 +168,7 @@ const App = () => {
           onClose={closeModal}
           onSubmit={onSubmitDeactivate}
         />
+        <SyncIndicator visible={isSyncing} />
         <SidePanel
           title={(panel && panel.data.heading) || ''}
           opened={panelOpen}

--- a/apps/allocations/app/components/Card/Empty.js
+++ b/apps/allocations/app/components/Card/Empty.js
@@ -1,15 +1,32 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { Button, EmptyStateCard, GU, unselectable } from '@aragon/ui'
+import { Button, EmptyStateCard, GU, LoadingRing, unselectable } from '@aragon/ui'
 import emptyState from '../../assets/no-budgets.svg'
 
 const illustration = <img src={emptyState} alt="No budgets" height="160" />
 
-const Empty = ({ action }) => (
+const Empty = ({ action, isSyncing }) => (
   <EmptyWrapper>
     <EmptyStateCard
-      text="No budgets here"
+      text={
+        isSyncing ? (
+          <div
+            css={`
+              display: grid;
+              align-items: center;
+              justify-content: center;
+              grid-template-columns: auto auto;
+              grid-gap: ${1 * GU}px;
+            `}
+          >
+            <LoadingRing />
+            <span>Syncing…</span>
+          </div>
+        ) : (
+          'No budgets here'
+        )}
+
       illustration={illustration}
       action={
         <Button onClick={action}>New budget</Button>
@@ -20,6 +37,7 @@ const Empty = ({ action }) => (
 
 Empty.propTypes = {
   action: PropTypes.func.isRequired,
+  isSyncing: PropTypes.bool.isRequired,
 }
 
 const EmptyWrapper = styled.div`

--- a/apps/dot-voting/app/App.js
+++ b/apps/dot-voting/app/App.js
@@ -1,13 +1,12 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
-import { EmptyStateCard, Header, Main } from '@aragon/ui'
+import { EmptyStateCard, GU, Header, LoadingRing, Main, SyncIndicator } from '@aragon/ui'
 import { useAragonApi } from './api-react'
 import { isBefore } from 'date-fns'
 import { getTotalSupport } from './utils/vote-utils'
 import { safeDiv } from './utils/math-utils'
 import { IdentityProvider } from './components/LocalIdentityBadge/IdentityManager'
 import Decisions from './Decisions'
-import { SyncCard } from '../../../shared/ui'
 import emptyStatePng from './assets/voting-empty-state.png'
 
 const ASSETS_URL = './aragon-ui'
@@ -50,7 +49,7 @@ Wrap.propTypes = {
   children: PropTypes.node.isRequired,
 }
 
-const CenterCard = ({ children }) => (
+const Empty = ({ isSyncing }) => (
   <Wrap>
     <div
       css={`
@@ -61,30 +60,33 @@ const CenterCard = ({ children }) => (
         z-index: -1;
       `}
     >
-      {children}
+      <EmptyStateCard
+        text={
+          isSyncing ? (
+            <div
+              css={`
+                display: grid;
+                align-items: center;
+                justify-content: center;
+                grid-template-columns: auto auto;
+                grid-gap: ${1 * GU}px;
+              `}
+            >
+              <LoadingRing />
+              <span>Syncing…</span>
+            </div>
+          ) : (
+            'After you create an allocation or issue curation, you can vote here.'
+          )}
+        illustration={illustration}
+      />
     </div>
   </Wrap>
 )
 
-CenterCard.propTypes = {
-  children: PropTypes.node.isRequired,
+Empty.propTypes = {
+  isSyncing: PropTypes.bool.isRequired,
 }
-
-const Empty = () => (
-  <CenterCard>
-    <EmptyStateCard
-      title="You do not have any dot votes."
-      text="After you create an allocation or issue curation, you can vote here."
-      illustration={illustration}
-    />
-  </CenterCard>
-)
-
-const Syncing = () => (
-  <CenterCard>
-    <SyncCard />
-  </CenterCard>
-)
 
 const App = () => {
   useVoteCloseWatcher()
@@ -117,8 +119,7 @@ const App = () => {
     }
   }, [ voteTime, pctBase ])
 
-  if (isSyncing) return <Syncing />
-  if (!votes.length) return <Empty />
+  if (!votes.length) return <Empty isSyncing={isSyncing}/>
 
   return (
     <Wrap>
@@ -127,6 +128,7 @@ const App = () => {
         onShowLocalIdentityModal={handleShowLocalIdentityModal}>
         <Header primary="Dot Voting" />
         <Decisions decorateVote={decorateVote} />
+        <SyncIndicator visible={isSyncing} />
       </IdentityProvider>
     </Wrap>
   )

--- a/apps/dot-voting/app/App.js
+++ b/apps/dot-voting/app/App.js
@@ -7,6 +7,7 @@ import { getTotalSupport } from './utils/vote-utils'
 import { safeDiv } from './utils/math-utils'
 import { IdentityProvider } from './components/LocalIdentityBadge/IdentityManager'
 import Decisions from './Decisions'
+import { SyncCard } from '../../../shared/ui'
 import emptyStatePng from './assets/voting-empty-state.png'
 
 const ASSETS_URL = './aragon-ui'
@@ -49,7 +50,7 @@ Wrap.propTypes = {
   children: PropTypes.node.isRequired,
 }
 
-const Empty = () => (
+const CenterCard = ({ children }) => (
   <Wrap>
     <div
       css={`
@@ -60,13 +61,29 @@ const Empty = () => (
         z-index: -1;
       `}
     >
-      <EmptyStateCard
-        title="You do not have any dot votes."
-        text="After you create an allocation or issue curation, you can vote here."
-        illustration={illustration}
-      />
+      {children}
     </div>
   </Wrap>
+)
+
+CenterCard.propTypes = {
+  children: PropTypes.node.isRequired,
+}
+
+const Empty = () => (
+  <CenterCard>
+    <EmptyStateCard
+      title="You do not have any dot votes."
+      text="After you create an allocation or issue curation, you can vote here."
+      illustration={illustration}
+    />
+  </CenterCard>
+)
+
+const Syncing = () => (
+  <CenterCard>
+    <SyncCard />
+  </CenterCard>
 )
 
 const App = () => {
@@ -84,7 +101,7 @@ const App = () => {
       .toPromise()
   }, [api])
 
-  const { votes = [], voteTime = 0, pctBase = 0 } = appState
+  const { isSyncing = true, votes = [], voteTime = 0, pctBase = 0 } = appState
 
   // TODO: move this logic to script.js so it's available app-wide by default
   const decorateVote = useCallback(vote => {
@@ -100,6 +117,7 @@ const App = () => {
     }
   }, [ voteTime, pctBase ])
 
+  if (isSyncing) return <Syncing />
   if (!votes.length) return <Empty />
 
   return (

--- a/apps/dot-voting/app/store/events.js
+++ b/apps/dot-voting/app/store/events.js
@@ -11,6 +11,20 @@ export const handleEvent = async (state, event) => {
     ...(!hasLoadedVoteSettings(state) ? await loadVoteSettings() : {}),
   }
   switch (eventName) {
+  case 'SYNC_STATUS_SYNCING': {
+    nextState = {
+      ...nextState,
+      isSyncing: true,
+    }
+    break
+  }
+  case 'SYNC_STATUS_SYNCED': {
+    nextState = {
+      ...nextState,
+      isSyncing: false,
+    }
+    break
+  }
   case 'CastVote':
     nextState = await castVote(nextState, returnValues)
     break

--- a/apps/dot-voting/app/store/init.js
+++ b/apps/dot-voting/app/store/init.js
@@ -3,6 +3,7 @@ import { app, handleEvent } from './'
 export const initStore = () => {
   const initialState = {
     votes: [],
+    isSyncing: false,
   }
   return app.store(
     async (state, event) => {

--- a/apps/dot-voting/app/store/init.js
+++ b/apps/dot-voting/app/store/init.js
@@ -20,6 +20,17 @@ export const initStore = () => {
       }
       // always return the state even unmodified
       return state
+    },
+    {
+      init: initState(),
     }
   )
+}
+
+const initState = () => async cachedState => {
+  const newState = {
+    ...cachedState,
+    isSyncing: true,
+  }
+  return newState
 }

--- a/apps/projects/app/App.js
+++ b/apps/projects/app/App.js
@@ -9,7 +9,6 @@ import {
   Header,
   IconPlus,
   Main,
-  SyncIndicator,
   Tabs,
 } from '@aragon/ui'
 
@@ -19,7 +18,6 @@ import IssueDetail from './components/Content/IssueDetail'
 import { PanelManager, PanelContext, usePanelManagement } from './components/Panel'
 
 import { IdentityProvider } from '../../../shared/identity'
-import { SyncCard } from '../../../shared/ui'
 import {
   REQUESTED_GITHUB_TOKEN_SUCCESS,
   REQUESTED_GITHUB_TOKEN_FAILURE,
@@ -50,7 +48,7 @@ const App = () => {
     issues = [],
     tokens = [],
     github = { status : STATUS.INITIAL },
-    isSyncing
+    isSyncing = true,
   } = appState
 
   const client = github.token ? initApolloClient(github.token) : null
@@ -129,13 +127,7 @@ const App = () => {
   }
 
   const noop = () => {}
-  if (isSyncing) {
-    return (
-      <EmptyWrapper>
-        <SyncCard />
-      </EmptyWrapper>
-    )
-  } else if (githubLoading) {
+  if (githubLoading) {
     return (
       <EmptyWrapper>
         <LoadingAnimation />
@@ -144,7 +136,7 @@ const App = () => {
   } else if (github.status === STATUS.INITIAL) {
     return (
       <Main>
-        <Unauthorized onLogin={handleGithubSignIn} />
+        <Unauthorized onLogin={handleGithubSignIn} isSyncing={isSyncing} />
       </Main>
     )
   } else if (github.status === STATUS.FAILED) {
@@ -225,7 +217,6 @@ const App = () => {
                   )
                 }
               </ErrorBoundary>
-              <SyncIndicator visible={isSyncing} />
               <PanelManager
                 activePanel={panel}
                 onClose={closePanel}

--- a/apps/projects/app/App.js
+++ b/apps/projects/app/App.js
@@ -9,6 +9,7 @@ import {
   Header,
   IconPlus,
   Main,
+  SyncIndicator,
   Tabs,
 } from '@aragon/ui'
 
@@ -224,7 +225,7 @@ const App = () => {
                   )
                 }
               </ErrorBoundary>
-
+              <SyncIndicator visible={isSyncing} />
               <PanelManager
                 activePanel={panel}
                 onClose={closePanel}

--- a/apps/projects/app/components/Content/Unauthorized.js
+++ b/apps/projects/app/components/Content/Unauthorized.js
@@ -1,32 +1,46 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Button, EmptyStateCard, Text, useTheme } from '@aragon/ui'
+import { Button, EmptyStateCard, GU, LoadingRing, Text, useTheme } from '@aragon/ui'
 import { EmptyWrapper } from '../Shared'
 
 import unauthorizedSvg from '../../assets/empty.svg'
 
 const illustration = <img src={unauthorizedSvg} alt="" height="160" />
 
-const Unauthorized = ({ onLogin }) => {
+const Unauthorized = ({ onLogin, isSyncing }) => {
   const theme = useTheme()
 
   return (
     <EmptyWrapper>
       <EmptyStateCard
-        text={<div>
-          <Text css="display: block; margin-bottom: 8px">
-            No projects here!
-          </Text>
-          <Text.Block size="small" color={`${theme.surfaceContentSecondary}`}>
-          Link your repositories to incentivize work with bounties
-          </Text.Block>
-        </div>
-        }
+        text={
+          isSyncing ? (
+            <div
+              css={`
+                display: grid;
+                align-items: center;
+                justify-content: center;
+                grid-template-columns: auto auto;
+                grid-gap: ${1 * GU}px;
+              `}
+            >
+              <LoadingRing />
+              <span>Syncing…</span>
+            </div>
+          ) : (
+            <React.Fragment>
+              <Text css={`margin: ${2 * GU}px`}>
+                Connect with GitHub
+              </Text>
+              <Text.Block size="small" color={`${theme.surfaceContentSecondary}`}>
+                Work on bounties, add funding to issues, or prioritize issues.
+              </Text.Block>
+            </React.Fragment>
+          )}
         illustration={illustration}
-        actionText="Connect to GitHub"
-        action={
-          <Button onClick={onLogin}>Connect to GitHub</Button>
-        }
+        action={ !isSyncing && (
+          <Button onClick={onLogin}>Sign In</Button>
+        )}
       />
     </EmptyWrapper>
   )
@@ -34,6 +48,7 @@ const Unauthorized = ({ onLogin }) => {
 
 Unauthorized.propTypes = {
   onLogin: PropTypes.func.isRequired,
+  isSyncing: PropTypes.bool.isRequired,
 }
 
 export default Unauthorized

--- a/apps/rewards/app/components/App/App.js
+++ b/apps/rewards/app/components/App/App.js
@@ -1,4 +1,4 @@
-import { Button, Header, IconPlus, Main, Tabs } from '@aragon/ui'
+import { Button, Header, IconPlus, Main, SyncIndicator, Tabs } from '@aragon/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
 import throttle from 'lodash.throttle'
@@ -42,6 +42,7 @@ class App extends React.Component {
     metrics: PropTypes.arrayOf(PropTypes.object).isRequired,
     myMetrics: PropTypes.arrayOf(PropTypes.object).isRequired,
     balances: PropTypes.arrayOf(PropTypes.object),
+    isSyncing: PropTypes.bool.isRequired,
     network: PropTypes.object,
     userAccount: PropTypes.string.isRequired,
     connectedAccount: PropTypes.string.isRequired,
@@ -67,6 +68,7 @@ class App extends React.Component {
     userAccount: '',
     refTokens: [],
     balances: [],
+    isSyncing: true,
   }
 
   static childContextTypes = {
@@ -272,14 +274,14 @@ class App extends React.Component {
       </Main>
     )
 
-    const { rewards, myRewards } = this.props
+    const { rewards, myRewards, isSyncing } = this.props
 
     if (!rewards || !myRewards) return null
     else if (!rewards.length && !myRewards.length) {
       return (
         <Wrapper>
           <EmptyContainer>
-            <Empty action={this.newReward} />
+            <Empty action={this.newReward} isSyncing={isSyncing} />
           </EmptyContainer>
         </Wrapper>
       )
@@ -303,7 +305,7 @@ class App extends React.Component {
           selected={this.state.selected}
           onChange={this.selectTab}
         />
-
+        <SyncIndicator visible={isSyncing} />
         { this.state.selected === 1 ? (
           <MyRewards
             myRewards={this.props.myRewards}

--- a/apps/rewards/app/components/Card/Empty.js
+++ b/apps/rewards/app/components/Card/Empty.js
@@ -1,16 +1,32 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { EmptyStateCard, GU, unselectable, Button } from '@aragon/ui'
+import { Button, EmptyStateCard, GU, LoadingRing, unselectable } from '@aragon/ui'
 import icon from '../../assets/empty-rewards.svg'
 
 const Icon = () => <img src={icon} height={20 * GU} />
 
-const Empty = ({ action, noButton=false }) => (
+const Empty = ({ action, isSyncing, noButton=false }) => (
 
   <EmptyWrapper>
     <EmptyStateCard
-      text="No rewards here!"
+      text={
+        isSyncing ? (
+          <div
+            css={`
+              display: grid;
+              align-items: center;
+              justify-content: center;
+              grid-template-columns: auto auto;
+              grid-gap: ${1 * GU}px;
+            `}
+          >
+            <LoadingRing />
+            <span>Syncing…</span>
+          </div>
+        ) : (
+          'No rewards here!'
+        )}
       illustration={<Icon />}
       action={noButton ? '' : <Button label="New reward" onClick={action} />}
     />
@@ -19,6 +35,7 @@ const Empty = ({ action, noButton=false }) => (
 
 Empty.propTypes = {
   action: PropTypes.func,
+  isSyncing: PropTypes.bool.isRequired,
 }
 
 const EmptyWrapper = styled.div`

--- a/apps/rewards/app/store/events.js
+++ b/apps/rewards/app/store/events.js
@@ -18,6 +18,12 @@ export const handleEvent = async (state, event, settings) => {
   }
   else {
     switch (eventName) {
+    case 'SYNC_STATUS_SYNCING':
+      nextState.isSyncing = true
+      break
+    case 'SYNC_STATUS_SYNCED':
+      nextState.isSyncing = false
+      break
     case 'RewardClaimed':
       nextState = await onRewardClaimed(nextState, returnValues)
       break


### PR DESCRIPTION
This merge ensures that all apps use caching in their background scripts and display a syncing message while cached events are being loaded. Generally, this means editing 4 files for each app:

app/store/init.js:
- This file sets the initial state with a `isSyncing` variable set to `false`.
- Initializes the state with the `cachedState` if available

app/store/events.js:
- The events file must watch for two events: `SYNC_STATUS_SYNCING` to set `isSyncing = true` and `SYNC_STATUS_SYNCED` to set `isSyncing = false`

app/components/App/App.js:
- The App.js file gets the `isSyncing` variable from the `appState` and passes it to the Empty card. Also, the SyncIndicator component is added to the main screen and is set to visible when `isSyncing == true`

app/components/Card/Empty.js
- This card now takes an `isSyncing` bool prop and displays a syncing message instead of the regular message if `isSyncing == true`

To test that the app correctly displays a syncing message you'll have make some calls to the app contract and then mine 100 blocks by calling `npm run mine 100` in the terminal. Then clear the cache and wait for the app to reload.