### PR TITLE
CODEOWNERS: use proxy teams

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -3,10 +3,10 @@
 
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-*       @AutarkLabs/engineers
+*       @AutarkLabs/engineers-pullassigner
 
 # Order is important; the last matching pattern takes the most
 # precedence. When someone opens a pull request that only
 # modifies solidity files, only the following owners will be
 # requested for a review.
-*.sol    @AutarkLabs/solidity-engineers
+*.sol    @AutarkLabs/solidity-engineers-pullassigner


### PR DESCRIPTION
I followed the instructions at https://docs.pullpanda.com/products/assigner/avoiding-team-notifications.  Now only one person will get a notification when Pull Assigner selects them as the reviewer.