### PR TITLE
Address Book: type badges font colors

### DIFF
--- a/apps/address-book/app/components/App/Entities.js
+++ b/apps/address-book/app/components/App/Entities.js
@@ -53,7 +53,7 @@ const Entities = ({ entities, onRemoveEntity }) => {
           <Tag
             background={type.bg}
             css="font-weight: bold"
-            foreground={type.fg}
+            color={type.fg}
             key="3"
             mode="identifier"
           >


### PR DESCRIPTION
Fixes #1509

The font colors of type badges were being set with a wrong prop, which
made them be the same purple color instead of the intended
colors. This PR fixes that.

![Screenshot from 2019-11-01 10-55-59](https://user-images.githubusercontent.com/16065447/68037678-46862080-fc96-11e9-8409-9f06946403b3.png)
