### PR TITLE
Dot Voting/EditVoteOption: improve number-input UX

### DIFF
--- a/apps/dot-voting/app/components/VoteDetails/CastVote/CastVote.js
+++ b/apps/dot-voting/app/components/VoteDetails/CastVote/CastVote.js
@@ -10,18 +10,20 @@ const CastVote = ({ onVote, toggleVotingMode, vote, voteWeights, votingPower }) 
 
   const [ voteAmounts, setVoteAmounts ] = useState(
     voteWeights.length
-      ? voteWeights.map(weight => parseInt(weight, 10))
-      : Array.from(Array(vote.data.options.length), () => 0)
+      ? voteWeights
+      : Array.from(Array(vote.data.options.length), () => '')
   )
 
   const [ remaining, setRemaining ] = useState(
-    100 - voteAmounts.reduce((sum, n) => sum + n, 0)
+    100 - voteAmounts.reduce((sum, n) => sum + Number(n), 0)
   )
 
   const updateVoteAmount = (idx, newValue) => {
+    if (Number(newValue) < 0) return
+
     const newVoteAmounts = [...voteAmounts]
-    newVoteAmounts[idx] = Math.round(newValue)
-    const total = newVoteAmounts.reduce((sum, n) => sum + n, 0)
+    newVoteAmounts[idx] = String(newValue)
+    const total = newVoteAmounts.reduce((sum, n) => sum + Number(n), 0)
 
     if (total <= 100) {
       setRemaining(100 - total)

--- a/apps/dot-voting/app/components/VoteDetails/CastVote/EditVoteOption.js
+++ b/apps/dot-voting/app/components/VoteDetails/CastVote/EditVoteOption.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { TextInput as AragonTextInput, useTheme } from '@aragon/ui'
@@ -7,6 +7,12 @@ import LocalIdentityBadge from '../../LocalIdentityBadge/LocalIdentityBadge'
 
 const Label = styled.div`
   width: 100%;
+`
+
+// a11y rules say inputs must have a label;
+// this adds the label for screenreaders but hides it visually
+const HiddenLabel = styled.label`
+  text-indent: -9999em;
 `
 
 const Inputs = styled.div`
@@ -46,6 +52,7 @@ const EditVoteOption = ({
   value,
 }) => {
   const theme = useTheme()
+  const input = useRef()
   return (
     <Wrap>
       <Label>
@@ -58,16 +65,23 @@ const EditVoteOption = ({
       </Label>
       <Inputs>
         <Slider
-          onUpdate={value => onUpdate(value * 100)}
+          onUpdate={x => onUpdate(Math.round(x * 100))}
           value={value / 100}
         />
+        <HiddenLabel htmlFor="percentage">Percentage</HiddenLabel>
         <TextInput
-          type="number"
+          name="percentage"
+          min={0}
+          onBlur={() => onUpdate(value) /* re-render component to reset input */}
+          onChange={e => onUpdate(e.target.value)}
+          ref={input}
           theme={theme}
-          value={value}
-          onChange={e => {
-            onUpdate(parseInt(e.target.value, 10))
-          }}
+          type="number"
+          value={
+            !value && input.current === document.activeElement
+              ? ''
+              : Number(value)
+          }
         />
       </Inputs>
     </Wrap>
@@ -77,7 +91,7 @@ const EditVoteOption = ({
 EditVoteOption.propTypes = {
   onUpdate: PropTypes.func.isRequired,
   label: PropTypes.string.isRequired,
-  value: PropTypes.number.isRequired,
+  value: PropTypes.string.isRequired,
 }
 
 export default EditVoteOption


### PR DESCRIPTION
* allow clearing input
* when clicking away from a cleared input, reset to 0
* also allow typing 0 – this required changing voteAmounts to strings!
* don't permit typing negative numbers
* add (visually-hidden) label, to improve screenreader experience

Also, a DX improvement:

* alphabetize props

<img alt="typing vote ux" src="https://user-images.githubusercontent.com/221614/68040100-ec8c5780-fca3-11e9-8376-3404425596bd.gif" width="350px">
