### PR TITLE
Rewards: give the asset dropdown panel space

### DIFF
--- a/apps/rewards/app/components/Panel/NewReward/NewReward.js
+++ b/apps/rewards/app/components/Panel/NewReward/NewReward.js
@@ -305,9 +305,8 @@ class NewRewardClass extends React.Component {
           min={MIN_AMOUNT}
           step="any"
           onChange={this.changeField}
-          wide={true}
           value={this.state.amount}
-          css={{ borderRadius: '4px 0px 0px 4px' }}
+          css="border-radius: 4px 0px 0px 4px; flex: 1"
         />
         <DropDown
           name="amountToken"


### PR DESCRIPTION
With the new dropdown icons, the asset symbols are getting truncated.
The fix here is to make the amount text box flex instead of wide, which
allows the dropdown to be as long as it needs to be, depending on the
number of characters in the symbol