### PR TITLE
Projects: request minimal set of permissions

### DIFF
--- a/apps/projects/app/components/Content/Unauthorized.js
+++ b/apps/projects/app/components/Content/Unauthorized.js
@@ -1,11 +1,26 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Button, EmptyStateCard, GU, LoadingRing, Text, useTheme } from '@aragon/ui'
+import {
+  Button,
+  EmptyStateCard,
+  Help,
+  GU,
+  Link,
+  LoadingRing,
+  Text,
+  useTheme,
+} from '@aragon/ui'
 import { EmptyWrapper } from '../Shared'
 
 import unauthorizedSvg from '../../assets/empty.svg'
 
 const illustration = <img src={unauthorizedSvg} alt="" height="160" />
+
+const InlineHelp = props => (
+  <div css={`display: inline-block; margin-left: ${GU}px`}>
+    <Help {...props} />
+  </div>
+)
 
 const Unauthorized = ({ onLogin, isSyncing }) => {
   const theme = useTheme()
@@ -31,6 +46,21 @@ const Unauthorized = ({ onLogin, isSyncing }) => {
             <React.Fragment>
               <Text css={`margin: ${2 * GU}px`}>
                 Connect with GitHub
+                <InlineHelp hint="">
+                  The Projects app requires you to sign in with GitHub, as the
+                  bounty and issue curation system is tied to GitHub issues.
+                  Granting this permission does not give any third party access
+                  to your GitHub account.{' '}
+                  <Link
+                    href="https://autark.gitbook.io/open-enterprise/apps/projects#github-authorization"
+                  >
+                    Read here
+                  </Link> for more details.
+                  <br /><br />
+                  Note: We are working towards decentralizing the Projects app
+                  to remove the need for GitHub: expect an update near the end
+                  of the year.
+                </InlineHelp>
               </Text>
               <Text.Block size="small" color={`${theme.surfaceContentSecondary}`}>
                 Work on bounties, add funding to issues, or prioritize issues.

--- a/apps/projects/app/components/Panel/NewIssue/AuthorizeGitHub.js
+++ b/apps/projects/app/components/Panel/NewIssue/AuthorizeGitHub.js
@@ -1,0 +1,89 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { useAragonApi } from '../../../api-react'
+import { Button, GU, Link, Text } from '@aragon/ui'
+import { LoadingAnimation } from '../../Shared'
+import {
+  REQUESTED_GITHUB_TOKEN_SUCCESS,
+  REQUESTED_GITHUB_TOKEN_FAILURE,
+} from '../../../store/eventTypes'
+import { getToken, githubPopup, STATUS } from '../../../utils/github'
+
+const Loading = () => (
+  <div css={`text-align: center; margin-top: ${15 * GU}px`}>
+    <LoadingAnimation />
+  </div>
+)
+
+const SCOPE = 'public_repo'
+let popupRef = null
+
+export default function AuthorizeGitHub() {
+  const { api } = useAragonApi()
+  const [ githubLoading, setGithubLoading ] = useState(false)
+
+  useEffect(() => {
+    window.addEventListener('message', handlePopupMessage)
+    return () => {
+      window.removeEventListener('message', handlePopupMessage)
+    }
+  })
+
+  const handlePopupMessage = useCallback(async message => {
+    if (!popupRef) return
+    if (message.source !== popupRef) return
+
+    popupRef = null
+
+    if (message.data.from !== 'popup') return
+    if (message.data.name === 'code') {
+      const code = message.data.value
+      try {
+        const token = await getToken(code)
+        api.emitTrigger(REQUESTED_GITHUB_TOKEN_SUCCESS, {
+          status: STATUS.AUTHENTICATED,
+          scope: SCOPE,
+          token
+        })
+      } catch (err) {
+        api.emitTrigger(REQUESTED_GITHUB_TOKEN_FAILURE, {
+          status: STATUS.FAILED,
+          scope: null,
+          token: null,
+        })
+      }
+    }
+  }, [])
+
+  const requestExtraPermissions = useCallback(() => {
+    setGithubLoading(true)
+    popupRef = githubPopup(popupRef, SCOPE)
+  }, [])
+
+  if (githubLoading) return <Loading />
+
+  return (
+    <>
+      <br />
+      <Text.Block size="xlarge">We’re going to need more permissions</Text.Block>
+      <br />
+      <Text.Block>
+        The Projects app can make GitHub issues on your behalf, but to do that
+        you need to increase the level of authorization granted to the app.
+        GitHub calls this level of permissions the “
+        <Link
+          href="https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/#available-scopes"
+        >public_repo scope</Link>”.
+        <br /><br />
+        Granting this permission does not give any third party access to your
+        GitHub account.{' '}
+        <Link
+          href="https://autark.gitbook.io/open-enterprise/apps/projects#github-authorization"
+        >Read here</Link> for more details.
+      </Text.Block>
+      <br />
+      <Button onClick={requestExtraPermissions} mode="strong">
+        I’m ready, authorize extra GitHub permissions
+      </Button>
+    </>
+  )
+}

--- a/apps/projects/app/components/Panel/NewIssue/NewIssue.js
+++ b/apps/projects/app/components/Panel/NewIssue/NewIssue.js
@@ -1,12 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Mutation } from 'react-apollo'
+import { useAragonApi } from '../../../api-react'
 import { Field, GU, TextInput, DropDown } from '@aragon/ui'
 import { NEW_ISSUE, GET_ISSUES } from '../../../utils/gql-queries.js'
 import { Form } from '../../Form'
 import { LoadingAnimation } from '../../Shared'
 import { usePanelManagement } from '../../Panel'
 import { useDecoratedRepos } from '../../../context/DecoratedRepos'
+import AuthorizeGitHub from './AuthorizeGitHub'
 
 // TODO: labels
 // TODO: import validator from '../data/validation'
@@ -177,6 +179,9 @@ class NewIssue extends React.PureComponent {
 const NewIssueWrap = () => {
   const { closePanel } = usePanelManagement()
   const repos = useDecoratedRepos()
+  const { appState: { github } } = useAragonApi()
+  if (!github.scope) return <AuthorizeGitHub />
+
   const repoNames = repos
     ? repos.map(repo => ({
       name: repo.metadata.name,

--- a/apps/projects/app/store/events.js
+++ b/apps/projects/app/store/events.js
@@ -56,13 +56,14 @@ export const handleEvent = async (state, action, vaultAddress, vaultContract) =>
     return state
   }
   case REQUESTED_GITHUB_TOKEN_SUCCESS: {
-    const { token } = returnValues
+    const { token, scope } = returnValues
     if (!token) return state
 
     state.github = {
-      token,
+      event: null,
+      scope,
       status: STATUS.AUTHENTICATED,
-      event: null
+      token,
     }
     app.cache('github', state.github).toPromise()
 

--- a/apps/projects/app/store/index.js
+++ b/apps/projects/app/store/index.js
@@ -9,6 +9,6 @@ export const INITIAL_STATE = {
   tokens: [],
   issues: [],
   bountySettings: {},
-  github: { status: STATUS.INITIAL, token: null, event: '' },
+  github: { event: '', scope: null, status: STATUS.INITIAL, token: null },
   isSyncing: false,
 }

--- a/apps/projects/app/utils/github.js
+++ b/apps/projects/app/utils/github.js
@@ -37,13 +37,13 @@ const getPopupDimensions = () => {
   return `width=${width},height=${height},top=${top},left=${left}`
 }
 
-export const githubPopup = (popup = null) => {
+export const githubPopup = (popup, scope) => {
   // Checks to save some memory if the popup exists as a window object
   if (popup === null || popup.closed) {
     popup = window.open(
       // TODO: Improve readability here: encode = (params: Object) => (JSON.stringify(params).replace(':', '=').trim())
       // encode url params
-      `${GITHUB_URI}?client_id=${CLIENT_ID}&scope=public_repo`,
+      `${GITHUB_URI}?client_id=${CLIENT_ID}&scope=${scope}`,
       'githubAuth',
       // TODO: Improve readability here: encode = (fields: Object) => (JSON.stringify(fields).replace(':', '=').trim())
       `scrollbars=no,toolbar=no,location=no,titlebar=no,directories=no,status=no,menubar=no, ${getPopupDimensions()}`


### PR DESCRIPTION
Fixes #1528

* Add help icon explaining why we need GitHub permissions

  ![initial github auth help icon](https://user-images.githubusercontent.com/221614/68333961-9c4c3580-00a7-11ea-8c2a-d086d078ec2f.gif)

* At first sign-in, request "no scopes", which gives only read access to public data. This is enough for viewing repositories + their issues, which is enough for most Projects functionality – creating & fulfilling bounties, reviewing bounty submissions, curating issues

  ![initial github auth](https://user-images.githubusercontent.com/221614/68170677-c59d8200-ff3e-11e9-887a-48a1e48bc9b7.gif)

* When creating new issues, explain [extra permissions required](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/#available-scopes), and allow user to give more permissions at this time. This is the only Projects action that requires increased permissions.

  ![extra permissions for creating issues](https://user-images.githubusercontent.com/221614/68161476-f6bc8900-ff23-11e9-90bc-5b8eb901f967.gif)
