### PR TITLE
Rewards erc20 fix

### DIFF
--- a/apps/rewards/app/store/token.js
+++ b/apps/rewards/app/store/token.js
@@ -81,7 +81,7 @@ export async function updateBalancesAndRefTokens({ balances = [], refTokens = []
   if (balancesIndex === -1) {
     const newBalance = await newBalanceEntry(tokenContract, tokenAddress, settings)
     let newRefTokens = Array.from(refTokens)
-    if (newBalance.startBlock) {
+    if (newBalance.startBlock !== null) {
       const refIndex = refTokens.findIndex(({ address }) =>
         addressesEqual(address, tokenAddress)
       )

--- a/apps/rewards/app/utils/token-utils.js
+++ b/apps/rewards/app/utils/token-utils.js
@@ -80,7 +80,13 @@ export async function getTokenStartBlock(app, address) {
   // creation block is optional; note that aragon.js doesn't return an error (only an falsey value) when
   // getting this value fails. It's only available for MiniMe Tokens
   let token = app.external(address, tokenCreationBlockAbi)
-  let tokenStartBlock = await token.creationBlock().toPromise()
+  let tokenStartBlock
+  try {
+    tokenStartBlock = await token.creationBlock().toPromise()
+  }
+  catch(e) {
+    tokenStartBlock = null
+  }
   return tokenStartBlock
 }
 
@@ -88,6 +94,12 @@ export async function getTransferable(app, address) {
   // creation block is optional; note that aragon.js doesn't return an error (only an falsey value) when
   // getting this value fails. It's only available for MiniMe Tokens
   let token = app.external(address, tokenTransferAbi)
-  let transferable = await token.transfersEnabled().toPromise()
+  let transferable 
+  try {
+    transferable = await token.transfersEnabled().toPromise()
+  }
+  catch (e) {
+    transferable = null
+  }
   return transferable
 }

--- a/shared/store-utils/token.js
+++ b/shared/store-utils/token.js
@@ -61,8 +61,6 @@ const loadTokenBalances = async (state, includedTokenAddresses, settings) => {
     newBalances.map(({address}) => address).concat(includedTokenAddresses || [])
   )
   for (const address of addresses) {
-    console.log('Loading new balances')
-
     newBalances = await updateBalances(newBalances, address, settings)
   }
 


### PR DESCRIPTION
In prior versions of web3, the `startBlock` and `transfersEnabled` would not throw when called on ERC20-compliant tokens that weren't Minime tokens. newer versions of web3 now throw errors, which they should, so this change will allow us to catch and handle those errors accordingly.
- resolves #1525 

I also removed that unnecessary log in the shared token-utils lib