### PR TITLE
Projects: fix token initialization issue

### DIFF
--- a/apps/projects/app/store/helpers/tokens.js
+++ b/apps/projects/app/store/helpers/tokens.js
@@ -7,7 +7,7 @@ const ETHER_TOKEN_FAKE_ADDRESS = '0x0000000000000000000000000000000000000000'
 const tokenAbi = [].concat(tokenDecimalsAbi, tokenSymbolAbi)
 
 export const initializeTokens = async (state, vaultContract) => {
-  const nextState = {
+  const nextState = state.tokens.find(t => t.symbol === 'ETH') ? state : {
     ...state,
     tokens: [{
       addr: ETHER_TOKEN_FAKE_ADDRESS,


### PR DESCRIPTION
Fixes #1437

Under certain conditions, i.e. when a large amount of blocks have been
mined since the last time there was a transaction involving the DAO
token and the browser is refreshed, the DAO token doesn't show up in
the base rate dropdown, under the Settings tab in the Projects app.

![Screenshot from 2019-11-05 19-11-01](https://user-images.githubusercontent.com/16065447/68258126-b6ccd300-0003-11ea-87ac-c860d95a984a.png)

This is due to the fact that, under these conditions, the store is
reinitialized and the following function from `store/init.js` gets executed:

    const initState = (vaultContract) => async (cachedState) => {
      let nextState = await initializeTokens(cachedState || INITIAL_STATE, vaultContract)
      [...]

Usually, `cachedState` is null, thus the INITIAL_STATE object is sent
as the first param of `initializeTokens()` from
`store/helpers/tokens.js`, which proceeds then to initialize the
tokens assuming no token exists already:

    export const initializeTokens = async (state, vaultContract) => {
      const nextState = {
        ...state,
        tokens: [{
          addr: ETHER_TOKEN_FAKE_ADDRESS,
          symbol: 'ETH',
          decimals: '18',
        }]
      }
      [...]

However, under the aforementioned conditions, `cachedState` contains
token objects, which get overwritten by the above code. The current PR
changes this behaviour so that token objects never get overwitten.

Being able to reproduce this bug was hard. On the original issue I
describe [the steps I took](https://github.com/AutarkLabs/open-enterprise/issues/1437#issuecomment-549912815) to do it.

This PR solves the bug as described there. However, this requires
further testing in order to make sure that there aren't other
instances in which this bug is still present.