### PR TITLE
Projects: Fix brief display of broken avatar on Settings page

### DIFF
--- a/apps/projects/app/components/Content/Settings.js
+++ b/apps/projects/app/components/Content/Settings.js
@@ -33,28 +33,21 @@ const fundingModels = [
   'Hourly',
 ]
 
-const GitHubConnect = ({ onLogin, onLogout, status }) => {
-  const user = useGithubAuth()
+const GitHubConnect = ({ onLogin, onLogout, user, status }) => {
   const theme = useTheme()
   const auth = status === STATUS.AUTHENTICATED
 
   const bodyText = auth ? (
     <Text size="large" css="display: flex; align-items: center">
       Logged in as
-      {user.avatarUrl ? (
-        <React.Fragment>
-          <img src={user.avatarUrl ? user.avatarUrl : ''} alt="user avatar" css="margin: 8px; width: 50px; border-radius: 50%;" />
-          <Link
-            href={user.url}
-            target="_blank"
-            style={{ textDecoration: 'none', color: `${theme.link}` }}
-          >
-            {user.login}
-          </Link>
-        </React.Fragment>
-      ) : (
-        <span css="margin: 8px; height: 50px;"></span>
-      )}
+      <img src={user.avatarUrl} alt="user avatar" css="margin: 8px; width: 50px; border-radius: 50%;" />
+      <Link
+        href={user.url}
+        target="_blank"
+        style={{ textDecoration: 'none', color: `${theme.link}` }}
+      >
+        {user.login}
+      </Link>
     </Text>
   ) : (
     <span css="line-height: 50px;">The Projects app uses GitHub to interact with issues.</span>
@@ -79,6 +72,7 @@ const GitHubConnect = ({ onLogin, onLogout, status }) => {
 GitHubConnect.propTypes = {
   onLogin: PropTypes.func.isRequired,
   onLogout: PropTypes.func.isRequired,
+  user: PropTypes.object.isRequired,
   status: PropTypes.string.isRequired,
 }
 
@@ -278,6 +272,7 @@ const Settings = ({ onLogin }) => {
   const [ settingsLoaded, setSettingsLoaded ] = useState(false)
 
   const { api, appState } = useAragonApi()
+  const user = useGithubAuth()
   const network = useNetwork()
   const { layoutName } = useLayout()
   const {
@@ -366,11 +361,11 @@ const Settings = ({ onLogin }) => {
     })
   }
 
-  if (!settingsLoaded)
+  if (!settingsLoaded  || !user.avatarUrl)
     return (
       <EmptyWrapper>
         <Text size="large" css={`margin-bottom: ${3 * GU}px`}>
-          Loading settings...
+          Loading...
         </Text>
         <LoadingAnimation />
       </EmptyWrapper>
@@ -389,6 +384,7 @@ const Settings = ({ onLogin }) => {
         <GitHubConnect
           onLogin={onLogin}
           onLogout={handleLogout}
+          user={user}
           status={github.status}
         />
       </div>

--- a/apps/projects/app/components/Content/Settings.js
+++ b/apps/projects/app/components/Content/Settings.js
@@ -40,17 +40,24 @@ const GitHubConnect = ({ onLogin, onLogout, status }) => {
 
   const bodyText = auth ? (
     <Text size="large" css="display: flex; align-items: center">
-      Logged in as <img src={user.avatarUrl} alt="user avatar" css="margin: 8px; width: 50px; border-radius: 50%;" />
-      <Link
-        href={user.url}
-        target="_blank"
-        style={{ textDecoration: 'none', color: `${theme.link}` }}
-      >
-        {user.login}
-      </Link>
+      Logged in as
+      {user.avatarUrl ? (
+        <React.Fragment>
+          <img src={user.avatarUrl ? user.avatarUrl : ''} alt="user avatar" css="margin: 8px; width: 50px; border-radius: 50%;" />
+          <Link
+            href={user.url}
+            target="_blank"
+            style={{ textDecoration: 'none', color: `${theme.link}` }}
+          >
+            {user.login}
+          </Link>
+        </React.Fragment>
+      ) : (
+        <span css="margin: 8px; height: 50px;"></span>
+      )}
     </Text>
   ) : (
-    'The Projects app uses GitHub to interact with issues.'
+    <span css="line-height: 50px;">The Projects app uses GitHub to interact with issues.</span>
   )
   const buttonText = auth ? 'Disconnect' : 'Connect my GitHub'
   const buttonAction = auth ? onLogout : onLogin

--- a/apps/projects/app/components/Content/Settings.js
+++ b/apps/projects/app/components/Content/Settings.js
@@ -39,8 +39,7 @@ const GitHubConnect = ({ onLogin, onLogout, user, status }) => {
 
   const bodyText = auth ? (
     <Text size="large" css="display: flex; align-items: center">
-      Logged in as
-      <img src={user.avatarUrl} alt="user avatar" css="margin: 8px; width: 50px; border-radius: 50%;" />
+      Logged in as <img src={user.avatarUrl} alt="user avatar" css="margin: 8px; width: 50px; border-radius: 50%;" />
       <Link
         href={user.url}
         target="_blank"
@@ -50,7 +49,7 @@ const GitHubConnect = ({ onLogin, onLogout, user, status }) => {
       </Link>
     </Text>
   ) : (
-    <span css="line-height: 50px;">The Projects app uses GitHub to interact with issues.</span>
+    'The Projects app uses GitHub to interact with issues.'
   )
   const buttonText = auth ? 'Disconnect' : 'Connect my GitHub'
   const buttonAction = auth ? onLogout : onLogin


### PR DESCRIPTION
Issue #1507 
- When you navigate to the Settings page you briefly see a broken image for the avatar
![image](https://user-images.githubusercontent.com/19808076/68363388-88bcc100-00df-11ea-858d-6d25f6a55c21.png)

- This fixes the problem by waiting to get the avatar url before displaying the page contents, while waiting it displays the loading message
![Peek 2019-11-06 21-48](https://user-images.githubusercontent.com/19808076/68363455-bace2300-00df-11ea-9381-ce18d8d4bfe7.gif)
