### PR TITLE
chore: remove no-unused-modules rule

### DIFF
--- a/apps/address-book/.eslintrc.js
+++ b/apps/address-book/.eslintrc.js
@@ -37,14 +37,14 @@ module.exports = {
     ],
     'func-style': ['warn', 'declaration', { allowArrowFunctions: true }],
     'object-curly-spacing': ['error', 'always'],
-    'import/no-unused-modules': [
-      'warn',
-      {
-        unusedExports: true,
-        missingExports: true,
-        ignoreExports: [],
-      },
-    ],
+    //'import/no-unused-modules': [
+    //  'warn',
+    //  {
+    //    unusedExports: true,
+    //    missingExports: true,
+    //    ignoreExports: [],
+    //  },
+    //],
     'no-undef': 'error',
     'no-unused-vars': [
       'warn',

--- a/apps/allocations/.eslintrc.js
+++ b/apps/allocations/.eslintrc.js
@@ -37,14 +37,14 @@ module.exports = {
     ],
     'func-style': ["warn", "declaration", { "allowArrowFunctions": true }],
     'object-curly-spacing': ['error', 'always'],
-    "import/no-unused-modules": [
-      "warn",
-      {
-        unusedExports: true,
-        missingExports: true,
-        ignoreExports: [],
-      }
-    ],
+    //"import/no-unused-modules": [
+    //  "warn",
+    //  {
+    //    unusedExports: true,
+    //    missingExports: true,
+    //    ignoreExports: [],
+    //  }
+    //],
     "no-undef": "error",
     "no-unused-vars": ["warn", { "vars": "all", "args": "after-used", "ignoreRestSiblings": false }],
     'no-console': ['warn', { allow: ['warn', 'error'] }],

--- a/apps/dot-voting/.eslintrc.js
+++ b/apps/dot-voting/.eslintrc.js
@@ -37,14 +37,14 @@ module.exports = {
     ],
     'func-style': ["warn", "declaration", { "allowArrowFunctions": true }],
     'object-curly-spacing': ['error', 'always'],
-    "import/no-unused-modules": [
-      "warn",
-      {
-        unusedExports: true,
-        missingExports: true,
-        ignoreExports: [],
-      }
-    ],
+    //"import/no-unused-modules": [
+    //  "warn",
+    //  {
+    //    unusedExports: true,
+    //    missingExports: true,
+    //    ignoreExports: [],
+    //  }
+    //],
     "no-undef": "error",
     "no-unused-vars": ["warn", { "vars": "all", "args": "after-used", "ignoreRestSiblings": false }],
     'no-console': ['warn', { allow: ['warn', 'error'] }],

--- a/apps/projects/.eslintrc.js
+++ b/apps/projects/.eslintrc.js
@@ -37,16 +37,16 @@ module.exports = {
     ],
     'func-style': ["warn", "declaration", { "allowArrowFunctions": true }],
     'object-curly-spacing': ['error', 'always'],
-    "import/no-unused-modules": [
-      "warn",
-      {
-        unusedExports: true,
-        missingExports: true,
-        ignoreExports: [
-          '**/test/*'
-        ],
-      }
-    ],
+    //"import/no-unused-modules": [
+    //  "warn",
+    //  {
+    //    unusedExports: true,
+    //    missingExports: true,
+    //    ignoreExports: [
+    //      '**/test/*'
+    //    ],
+    //  }
+    //],
     "no-undef": "error",
     "no-unused-vars": ["warn", { "vars": "all", "args": "after-used", "ignoreRestSiblings": false }],
     'no-console': ['warn', { allow: ['warn', 'error'] }],

--- a/apps/rewards/.eslintrc.js
+++ b/apps/rewards/.eslintrc.js
@@ -35,23 +35,23 @@ module.exports = {
       }
     ],
     'object-curly-spacing': ['error', 'always'],
-    'import/no-unused-modules': [
-      1,
-      {
-        unusedExports: true,
-        missingExports: true,
-        ignoreExports: [
-          'app/index.js', // no exports
-          'app/script.js', // no exports
-          'app/components/Content/MyRewards.js', // used by index.js and App.js but not detected by linter
-          'app/components/Content/Overview.js', // used by index.js and App.js but not detected by linter
-          'app/components/Panel/index.js', // used by App.js but not detected by linter
-          'app/components/Panel/MyReward/index.js', // used by PanelManager.js but not detected by linter
-          'app/components/Panel/NewReward/index.js', // used by PanelManager.js but not detected by linter
-          'app/components/Panel/ViewReward/index.js', // used by PanelManager.js but not detected by linter
-        ],
-      }
-    ],
+    //'import/no-unused-modules': [
+    //  1,
+    //  {
+    //    unusedExports: true,
+    //    missingExports: true,
+    //    ignoreExports: [
+    //      'app/index.js', // no exports
+    //      'app/script.js', // no exports
+    //      'app/components/Content/MyRewards.js', // used by index.js and App.js but not detected by linter
+    //      'app/components/Content/Overview.js', // used by index.js and App.js but not detected by linter
+    //      'app/components/Panel/index.js', // used by App.js but not detected by linter
+    //      'app/components/Panel/MyReward/index.js', // used by PanelManager.js but not detected by linter
+    //      'app/components/Panel/NewReward/index.js', // used by PanelManager.js but not detected by linter
+    //      'app/components/Panel/ViewReward/index.js', // used by PanelManager.js but not detected by linter
+    //    ],
+    //  }
+    //],
     'no-undef': 'error',
     'no-unused-vars': ['warn', { 'vars': 'all', 'args': 'after-used', 'ignoreRestSiblings': false }],
     'react/jsx-uses-react': 'warn',

--- a/shared/ui/.eslintrc.js
+++ b/shared/ui/.eslintrc.js
@@ -37,14 +37,14 @@ module.exports = {
     ],
     'func-style': ["warn", "declaration", { "allowArrowFunctions": true }],
     'object-curly-spacing': ['error', 'always'],
-    "import/no-unused-modules": [
-      "warn",
-      {
-        unusedExports: true,
-        missingExports: true,
-        ignoreExports: [],
-      }
-    ],
+    //"import/no-unused-modules": [
+    //  "warn",
+    //  {
+    //    unusedExports: true,
+    //    missingExports: true,
+    //    ignoreExports: [],
+    //  }
+    //],
     "no-undef": "error",
     "no-unused-vars": ["warn", { "vars": "all", "args": "after-used", "ignoreRestSiblings": false }],
     'no-console': ['warn', { allow: ['warn', 'error'] }],


### PR DESCRIPTION
This rule causes all of our linting IDE integrations to move very
slowly, and I think commenting this out for now will enhance our
workflows. Note that I'm only commenting it out because I think it's
very useful when we want to optimize our builds. HOwever, for day-to-day
bugfixing and dev work it's probably not necessary