### PR TITLE
bugfix: remove budget edits for now

### DIFF
--- a/apps/allocations/app/components/Card/Budget.js
+++ b/apps/allocations/app/components/Card/Budget.js
@@ -74,10 +74,10 @@ const Budget = ({
             <IconPlus />
             <ActionLabel>New Allocation</ActionLabel>
           </ContextMenuItem>
-          <ContextMenuItem onClick={edit}>
-            <IconEdit />
-            <ActionLabel>Edit</ActionLabel>
-          </ContextMenuItem>
+          {/*<ContextMenuItem onClick={edit}>*/}
+          {/*  <IconEdit />*/}
+          {/*  <ActionLabel>Edit</ActionLabel>*/}
+          {/*</ContextMenuItem>*/}
           {/* <ContextMenuItem onClick={deactivate}> */}
           {/*   <IconProhibited /> */}
           {/*   <ActionLabel>Deactivate</ActionLabel> */}


### PR DESCRIPTION
editing a budget requires fixing the currecny box so it displays the
right symbol, as well as fixing the radspec so it works as expected