### PR TITLE
bugfix: utilize addressesEqual function

### DIFF
--- a/apps/allocations/app/app-state-reducer.js
+++ b/apps/allocations/app/app-state-reducer.js
@@ -1,5 +1,6 @@
 import { BigNumber } from 'bignumber.js'
 import { ETHER_TOKEN_FAKE_ADDRESS } from '../../../shared/lib/token-utils'
+import { addressesEqual } from '../../../shared/lib/web3-utils'
 
 // Use this function to sort by ETH and then token symbol
 const compareBalancesByEthAndSymbol = (tokenA, tokenB) => {
@@ -14,7 +15,7 @@ const compareBalancesByEthAndSymbol = (tokenA, tokenB) => {
 
 const getTokenFromAddress = (tokenAddress, tokenList) => {
   if (!tokenList || !tokenList.length) return tokenAddress
-  return tokenList.find(token => token.address === tokenAddress)
+  return tokenList.find(token => addressesEqual(token.address, tokenAddress))
 }
 
 function appStateReducer(state) {

--- a/apps/allocations/app/components/App/AllocationsHistory.js
+++ b/apps/allocations/app/components/App/AllocationsHistory.js
@@ -16,6 +16,7 @@ import styled from 'styled-components'
 
 import { STATUSES } from '../../utils/constants'
 import { displayCurrency } from '../../utils/helpers'
+import { addressesEqual } from '../../../../../shared/lib/web3-utils'
 
 const AllocationsHistory = ({ allocations }) => {
   const theme = useTheme()
@@ -23,7 +24,7 @@ const AllocationsHistory = ({ allocations }) => {
   const { balances = [], budgets = [] } = useAppState()
   const network = useNetwork()
   const getTokenSymbol = inputAddress => {
-    const matchingBalance = balances.find(({ address }) => inputAddress === address)
+    const matchingBalance = balances.find(({ address }) => addressesEqual(inputAddress, address))
     return matchingBalance ? matchingBalance.symbol : ''
   }
   const getBudgetName = inputId => {

--- a/apps/allocations/app/components/App/Payouts.js
+++ b/apps/allocations/app/components/App/Payouts.js
@@ -15,6 +15,7 @@ import {
   theme,
 } from '@aragon/ui'
 
+import { addressesEqual } from '../../../../../shared/lib/web3-utils'
 import { displayCurrency, sortByDateKey } from '../../utils/helpers'
 import {
   AmountBadge,
@@ -28,7 +29,7 @@ const translateToken = (payoutToken, tokens) => {
   if (payoutToken === '0x0000000000000000000000000000000000000000') {
     return 'ETH'
   }
-  const index = tokens.findIndex(a => a.address === payoutToken)
+  const index = tokens.findIndex(a => addressesEqual(a.address, payoutToken))
   if (index > 0) {
     return tokens[index].symbol
   }

--- a/apps/allocations/app/components/Panel/NewAllocation.js
+++ b/apps/allocations/app/components/Panel/NewAllocation.js
@@ -5,6 +5,7 @@ import web3Utils from 'web3-utils'
 import styled from 'styled-components'
 import { BigNumber } from 'bignumber.js'
 
+import { addressesEqual } from '../../../../../shared/lib/web3-utils'
 import { RecipientsInput } from '../../../../../shared/ui'
 import { MIN_AMOUNT } from '../../utils/constants'
 import { displayCurrency, isStringEmpty } from '../../utils/helpers'
@@ -166,7 +167,7 @@ class NewAllocation extends React.Component {
     } = this.state
 
     const remainingBudget = displayCurrency(BigNumber(budgetValue.remaining))
-    const inVault = displayCurrency(balances.find(b => b.address === tokenValue.address).amount)
+    const inVault = displayCurrency(balances.find(b => addressesEqual(b.address, tokenValue.address)).amount)
 
     const budgetDropDown = (
       <FormField

--- a/apps/dot-voting/app/store/votes.js
+++ b/apps/dot-voting/app/store/votes.js
@@ -4,6 +4,7 @@ import { first, map, mergeMap } from 'rxjs/operators'
 import { app } from './'
 import { EMPTY_CALLSCRIPT } from '../utils/vote-utils'
 import { ETHER_TOKEN_FAKE_ADDRESS, getTokenSymbol } from '../../../../shared/lib/token-utils'
+import { addressesEqual } from '../../../../shared/lib/web3-utils'
 import allocationsAbi from '../../../shared/json-abis/allocations'
 
 export const castVote = async (state, { voteId }) => {
@@ -270,7 +271,7 @@ const decorateVote = async (vote) => {
       first(),
       mergeMap(installedApps => from(installedApps)),
       first(
-        app => app.appAddress === targetAddress,
+        app => addressesEqual(app.appAddress, targetAddress),
         {
           appAddress: targetAddress,
           name: 'External',

--- a/apps/rewards/app/app-state-reducer.js
+++ b/apps/rewards/app/app-state-reducer.js
@@ -7,6 +7,7 @@ import {
   YEARS,
   WEEKS,
 } from './utils/constants'
+import { addressesEqual } from '../../../shared/lib/web3-utils'
 import {
   calculateAverageRewardsNumbers,
   calculateMyRewardsSummary
@@ -59,9 +60,9 @@ function appStateReducer(state) {
           reward.rewardType = ONE_TIME_DIVIDEND
           reward.dateReference = new Date(reward.endDate)
         }
-        const referenceAssetToken = state.refTokens.find( token => token.address === reward.referenceToken)
+        const referenceAssetToken = state.refTokens.find( token => addressesEqual(token.address, reward.referenceToken))
         reward.referenceTokenSymbol = referenceAssetToken.symbol
-        const amountToken = state.amountTokens.find( token => token.address === reward.rewardToken)
+        const amountToken = state.amountTokens.find( token => addressesEqual(token.address, reward.rewardToken))
         reward.amountToken = amountToken.symbol
         rewards.push(reward)
       }

--- a/apps/rewards/app/components/Panel/NewReward/NewReward.js
+++ b/apps/rewards/app/components/Panel/NewReward/NewReward.js
@@ -26,7 +26,7 @@ import {
 import moment from 'moment'
 import { isBefore } from 'date-fns'
 import { BigNumber } from 'bignumber.js'
-import { isAddress } from '../../../utils/web3-utils'
+import { isAddress, addressesEqual } from '../../../../../../shared/lib/web3-utils'
 import { ETHER_TOKEN_VERIFIED_BY_SYMBOL } from '../../../utils/verified-tokens'
 import TokenSelectorInstance from './TokenSelectorInstance'
 import {
@@ -264,7 +264,7 @@ class NewRewardClass extends React.Component {
       else return nullAsset
     }
     const selectedToken = refTokens.find(t => (
-      t.address === referenceAsset.props.address
+      addressesEqual(t.address, referenceAsset.props.address)
     ))
     return selectedToken
   }

--- a/apps/rewards/app/store/reward.js
+++ b/apps/rewards/app/store/reward.js
@@ -1,6 +1,7 @@
 import { first, map } from 'rxjs/operators'
 import { app } from './'
 import { blocksToMilliseconds } from '../../../../shared/ui/utils'
+import { addressesEqual } from '../../../../shared/lib/web3-utils'
 import { updateBalancesAndRefTokens } from './token'
 
 
@@ -25,7 +26,7 @@ export async function onRewardClaimed({ rewards = [], claims = {} }, { rewardId 
 
   let { claimsByToken = [], totalClaimsMade = 0 } = claims
 
-  const tokenIndex = claimsByToken.findIndex(token => token.address === rewards[rewardId].rewardToken)
+  const tokenIndex = claimsByToken.findIndex(token => addressesEqual(token.address, rewards[rewardId].rewardToken))
 
   if (tokenIndex === -1) {
     claimsByToken.push({

--- a/apps/rewards/app/utils/metric-utils.js
+++ b/apps/rewards/app/utils/metric-utils.js
@@ -1,5 +1,6 @@
 import BigNumber from 'bignumber.js'
 import { MILLISECONDS_IN_A_MONTH } from '../../../../shared/ui/utils/math-utils'
+import { addressesEqual } from '../../../../shared/lib/web3-utils'
 
 export const calculateAverageRewardsNumbers = ( rewards, claims, balances, convertRates ) => {
   if (balances && convertRates) {
@@ -20,7 +21,7 @@ const calculateAvgClaim = ({ claimsByToken, totalClaimsMade }, balances, convert
     claimsByToken,
     balances,
     convertRates,
-    (claim, bal) => claim.address === bal.address
+    (claim, bal) => addressesEqual(claim.address, bal.address)
   ) / totalClaimsMade
 }
 
@@ -40,7 +41,7 @@ const calculateMonthlyAvg = (rewards, balances, convertRates) => {
     rewards,
     balances,
     convertRates,
-    (rew, bal) => rew.rewardToken === bal.address
+    (rew, bal) => addressesEqual(rew.rewardToken, bal.address)
   )
   const monthlyAvg = totalRewards / monthsFromNow
   return monthlyAvg
@@ -52,7 +53,7 @@ const calculateYTDRewards = (rewards, balances, convertRates) => {
     rewards,
     balances,
     convertRates,
-    (rew, bal) => rew.rewardToken === bal.address && rew.endDate >= yearBeginning
+    (rew, bal) => addressesEqual(rew.rewardToken, bal.address) && rew.endDate >= yearBeginning
   )
   return totalRewards
 }
@@ -91,7 +92,7 @@ const calculateUnclaimedRewards = (rewards, balances, convertRates) => {
     rewards,
     balances,
     convertRates,
-    (rew, bal) => !rew.claimed && rew.rewardToken === bal.address // rewardFilter
+    (rew, bal) => !rew.claimed && addressesEqual(rew.rewardToken, bal.address) // rewardFilter
   )
 }
 
@@ -100,7 +101,7 @@ const calculateAllRewards = (rewards, balances, convertRates) => {
     rewards,
     balances,
     convertRates,
-    (rew, bal) => rew.claimed && rew.rewardToken === bal.address, // RewardFilter
+    (rew, bal) => rew.claimed && addressesEqual(rew.rewardToken, bal.address), // RewardFilter
   )
 }
 
@@ -110,7 +111,7 @@ const calculateYTDUserRewards = (rewards, balances, convertRates) => {
     rewards,
     balances,
     convertRates,
-    (rew, bal) => rew.claimed && rew.rewardToken === bal.address && rew.endDate >= yearBeginning
+    (rew, bal) => rew.claimed && addressesEqual(rew.rewardToken, bal.address) && rew.endDate >= yearBeginning
   )
 }
 


### PR DESCRIPTION
Some token contracts (such as DAI) return a contract address where all
alphabet characters are lowercased during a deposit. This can cause
issues if another event returns the case-sensitive address when doing a
search or filter comparison. Utilizing the addressesEqual function
elminates these issues by comparing the addresses via checksum instead.

This resolves the issues we were seeing in the app-state-reducer where `token.symbol` returns a "cannot find symbol of undefined" error.

This change has been verified to resolve the issues we were seeing with mainnet DAI in rewards, allocations, and related forwarders