### PR TITLE
chore: remove token from template projects args

### DIFF
--- a/templates/dev/contracts/DevTemplate.sol
+++ b/templates/dev/contracts/DevTemplate.sol
@@ -167,7 +167,7 @@ contract DevTemplate is BaseOEApps {
         AddressBook addressBook = _installAddressBookApp(_dao);
         Allocations allocations = _installAllocationsApp(_dao, _vault, _allocationsPeriod == 0 ? DEFAULT_PERIOD : _allocationsPeriod);
         DotVoting dotVoting = _installDotVotingApp(_dao, token, _dotVotingSettings);
-        Projects projects = _installProjectsApp(_dao, _vault, token);
+        Projects projects = _installProjectsApp(_dao, _vault);
         Rewards rewards = _installRewardsApp(_dao, _vault);
 
         _setupOEPermissions(

--- a/templates/open-enterprise/contracts/BaseOEApps.sol
+++ b/templates/open-enterprise/contracts/BaseOEApps.sol
@@ -132,8 +132,8 @@ contract BaseOEApps is BaseCache, TokenCache {
 
     /* PROJECTS */
 
-    function _installProjectsApp(Kernel _dao, Vault _vault, MiniMeToken _token) internal returns (Projects) {
-        bytes memory initializeData = abi.encodeWithSelector(Projects(0).initialize.selector, bountiesRegistry, _vault, _token);
+    function _installProjectsApp(Kernel _dao, Vault _vault) internal returns (Projects) {
+        bytes memory initializeData = abi.encodeWithSelector(Projects(0).initialize.selector, bountiesRegistry, _vault);
         return Projects(_installNonDefaultApp(_dao, PROJECTS_APP_ID, initializeData));
     }
 

--- a/templates/open-enterprise/contracts/OpenEnterpriseTemplate.sol
+++ b/templates/open-enterprise/contracts/OpenEnterpriseTemplate.sol
@@ -168,7 +168,7 @@ contract OpenEnterpriseTemplate is BaseOEApps {
         AddressBook addressBook = _installAddressBookApp(_dao);
         Allocations allocations = _installAllocationsApp(_dao, _vault, _allocationsPeriod == 0 ? DEFAULT_PERIOD : _allocationsPeriod);
         DotVoting dotVoting = _installDotVotingApp(_dao, token, _dotVotingSettings);
-        Projects projects = _installProjectsApp(_dao, _vault, token);
+        Projects projects = _installProjectsApp(_dao, _vault);
         Rewards rewards = _installRewardsApp(_dao, _vault);
 
         _setupOEPermissions(


### PR DESCRIPTION
The token was deprecated as an intialization parameter in our mainnet
contract work. The `encodeWithSelector` function appears to have just
dropped the unnecessary token arg when creating the initialization
bytecode for the projects contract, so now it's finally getting removed