### PR TITLE
Projects: Context menu sentence case

### DIFF
--- a/apps/projects/app/components/Panel/FundIssues/FundIssues.js
+++ b/apps/projects/app/components/Panel/FundIssues/FundIssues.js
@@ -506,10 +506,10 @@ const FundIssues = ({ issues, mode }) => {
       {(alreadyAdded.length > 0) && (
         <Info.Action title="Warning" style={{ marginBottom: `${2 * GU}px` }}>
           <p style={{ margin: '10px 0' }}>
-          The following issues already have bounties and cannot be updated on a bulk basis. To update an individual issue, select “Update Bounty” from the issue’s context menu.
+          The following issues already have active bounties, so they have been discarded from this funding proposal:
           </p>
           <WarningIssueList>
-            {issues.map(issue => <li key={issue.id}>{issue.title}</li>)}
+            {alreadyAdded.map(issue => <li key={issue.id}>{issue.title}</li>)}
           </WarningIssueList>
         </Info.Action>
       )}

--- a/apps/projects/app/components/Shared/BountyContextMenu.js
+++ b/apps/projects/app/components/Shared/BountyContextMenu.js
@@ -22,7 +22,7 @@ const BountyContextMenu = ({ issue }) => {
         <Item onClick={() => allocateBounty([issue])}>
           <IconCoin color={`${theme.surfaceIcon}`} />
           <ActionLabel>
-            Fund Issue
+            Fund issue
           </ActionLabel>
         </Item>
       )}
@@ -31,7 +31,7 @@ const BountyContextMenu = ({ issue }) => {
           <Item onClick={() => submitWork(issue)}>
             <IconConnect color={`${theme.surfaceIcon}`} />
             <ActionLabel>
-              Submit Work
+              Submit work
             </ActionLabel>
           </Item>
         </React.Fragment>
@@ -41,7 +41,7 @@ const BountyContextMenu = ({ issue }) => {
           <Item onClick={() => reviewWork(issue)}>
             <IconView color={`${theme.surfaceIcon}`} />
             <ActionLabel>
-              Review Work
+              Review work
             </ActionLabel>
           </Item>
         </React.Fragment>
@@ -51,7 +51,7 @@ const BountyContextMenu = ({ issue }) => {
           <Item onClick={() => requestAssignment(issue)}>
             <IconFile color={`${theme.surfaceIcon}`} />
             <ActionLabel>
-              Submit Application
+              Submit application
             </ActionLabel>
           </Item>
           {/* Disabled since the contract doesn't allow updating the amount */}
@@ -65,13 +65,13 @@ const BountyContextMenu = ({ issue }) => {
           <Item onClick={() => requestAssignment(issue)}>
             <IconFile color={`${theme.surfaceIcon}`} />
             <ActionLabel>
-              Submit Application
+              Submit application
             </ActionLabel>
           </Item>
           <Item onClick={() => reviewApplication(issue)}>
             <IconView color={`${theme.surfaceIcon}`} />
             <ActionLabel>
-              Review Application {issue.requestsData ? `(${issue.requestsData.length})` : ''}
+              Review application {issue.requestsData ? `(${issue.requestsData.length})` : ''}
             </ActionLabel>
           </Item>
           {/* Disabled since the contract doesn't allow updating the amount */}

--- a/apps/projects/app/components/Shared/FilterBar/FilterBar.js
+++ b/apps/projects/app/components/Shared/FilterBar/FilterBar.js
@@ -170,7 +170,7 @@ const ActionsPopover = ({ visible, setVisible, openerRef, selectedIssues, issues
         }}
       >
         <IconFilter />
-        <ActionLabel>Curate Issues</ActionLabel>
+        <ActionLabel>Curate issues</ActionLabel>
       </FilterMenuItem>
       <FilterMenuItem
         onClick={() => {
@@ -180,7 +180,7 @@ const ActionsPopover = ({ visible, setVisible, openerRef, selectedIssues, issues
         }}
       >
         <IconCoins />
-        <ActionLabel>Fund Issues</ActionLabel>
+        <ActionLabel>Fund issues</ActionLabel>
       </FilterMenuItem>
     </Popover>
   )


### PR DESCRIPTION
Gave sentence case to context menus:
![Screenshot from 2019-11-19 10-47-55](https://user-images.githubusercontent.com/19808076/69176248-4077a880-0aba-11ea-994a-5ee7c3cda734.png)
![Screenshot from 2019-11-19 10-48-12](https://user-images.githubusercontent.com/19808076/69176260-47062000-0aba-11ea-84e0-25909258bb32.png)

And fixed the language for the message when funding multiple issues where an issue is already funded. Additionally, listing only the funded issues (all issues used to be listed):
![Screenshot from 2019-11-19 10-48-36](https://user-images.githubusercontent.com/19808076/69176387-7ddc3600-0aba-11ea-87bb-818d8f193947.png)

Also, Issue #1571 also required that the 'Update funding' option be removed, but that was done on an earlier PR.