### PR TITLE
Allocations: New panel gets fresh state

### DIFF
--- a/apps/allocations/app/components/Panel/NewAllocation.js
+++ b/apps/allocations/app/components/Panel/NewAllocation.js
@@ -54,7 +54,7 @@ class NewAllocation extends React.Component {
   constructor(props) {
     super(props)
     const { budgets, budgetId } = props
-    this.state = INITIAL_STATE
+    this.state = { ...INITIAL_STATE }
     this.state.recipients = {}
     this.state.recipientsValid = {}
     const recipientId = Date.now()

--- a/apps/allocations/app/components/Panel/NewBudget.js
+++ b/apps/allocations/app/components/Panel/NewBudget.js
@@ -39,7 +39,7 @@ class NewBudget extends React.Component {
 
   constructor(props) {
     super(props)
-    this.state =  INITIAL_STATE
+    this.state = { ...INITIAL_STATE }
     if (props.editingBudget.id) {
       this.state.name = props.editingBudget.name
       this.state.nameError = false


### PR DESCRIPTION
Fix for issue #1584:

Before the panel state would update the INITIAL_STATE const on updates, so anytime the panel state was initialized it would just get the last state instead of a new state.

Also, it should be noted that the 'Edit budget' option has been removed from the context menu. I'm not sure why this was done so I left it that way. Whenever we decide to have an 'Edit budget' again this state problem will be fixed.