### PR TITLE
Allocations: Fix edit budget symbol

### DIFF
--- a/apps/allocations/app/components/Card/Budget.js
+++ b/apps/allocations/app/components/Card/Budget.js
@@ -74,10 +74,10 @@ const Budget = ({
             <IconPlus />
             <ActionLabel>New Allocation</ActionLabel>
           </ContextMenuItem>
-          {/*<ContextMenuItem onClick={edit}>*/}
-          {/*  <IconEdit />*/}
-          {/*  <ActionLabel>Edit</ActionLabel>*/}
-          {/*</ContextMenuItem>*/}
+          <ContextMenuItem onClick={edit}>
+            <IconEdit />
+            <ActionLabel>Edit</ActionLabel>
+          </ContextMenuItem>
           {/* <ContextMenuItem onClick={deactivate}> */}
           {/*   <IconProhibited /> */}
           {/*   <ActionLabel>Deactivate</ActionLabel> */}

--- a/apps/allocations/app/components/Panel/NewBudget.js
+++ b/apps/allocations/app/components/Panel/NewBudget.js
@@ -46,7 +46,6 @@ class NewBudget extends React.Component {
       this.state.amount = BigNumber(props.editingBudget.amount)
         .div(ETH_DECIMALS)
       this.state.amountError = false
-      this.state.selectedToken = 0
       this.state.buttonText = 'Submit'
     }
   }

--- a/apps/allocations/app/components/Panel/NewBudget.js
+++ b/apps/allocations/app/components/Panel/NewBudget.js
@@ -41,12 +41,13 @@ class NewBudget extends React.Component {
     super(props)
     this.state =  INITIAL_STATE
     if (props.editingBudget.id) {
+      const tokenIndex = props.tokens.findIndex(token => token.symbol === props.editingBudget.token.symbol)
       this.state.name = props.editingBudget.name
       this.state.nameError = false
       this.state.amount = BigNumber(props.editingBudget.amount)
         .div(ETH_DECIMALS)
       this.state.amountError = false
-      this.state.selectedToken = props.editingBudget.token.symbol === 'ETH' ? 0 : 1
+      this.state.selectedToken = tokenIndex === -1 ? 0 : tokenIndex //Default to ETH if index not found?
       this.state.buttonText = 'Submit'
     }
   }

--- a/apps/allocations/app/components/Panel/NewBudget.js
+++ b/apps/allocations/app/components/Panel/NewBudget.js
@@ -41,13 +41,12 @@ class NewBudget extends React.Component {
     super(props)
     this.state =  INITIAL_STATE
     if (props.editingBudget.id) {
-      const tokenIndex = props.tokens.findIndex(token => token.symbol === props.editingBudget.token.symbol)
       this.state.name = props.editingBudget.name
       this.state.nameError = false
       this.state.amount = BigNumber(props.editingBudget.amount)
         .div(ETH_DECIMALS)
       this.state.amountError = false
-      this.state.selectedToken = tokenIndex === -1 ? 0 : tokenIndex //Default to ETH if index not found?
+      this.state.selectedToken = 0
       this.state.buttonText = 'Submit'
     }
   }
@@ -131,7 +130,7 @@ class NewBudget extends React.Component {
               wide
             />
             {this.props.editingBudget.id ? (
-              <CurrencyBox>{symbols[selectedToken]}</CurrencyBox>
+              <CurrencyBox>{this.props.editingBudget.token.symbol}</CurrencyBox>
             ) : (
               <DropDown
                 name="token"

--- a/apps/allocations/contracts/Allocations.sol
+++ b/apps/allocations/contracts/Allocations.sol
@@ -300,7 +300,7 @@ contract Allocations is AragonApp {
     }
 
     /**
-    * @notice Update budget #`_accountId` to `@tokenAmount(0, _amount, false)`, effective immediately and optionally update metadata
+    * @notice Update budget #`_accountId` to `@tokenAmount(0x0000000000000000000000000000000000000000, _amount, false)`, effective immediately and optionally update metadata
     * @param _accountId Budget Identifier
     * @param _amount New budget amount
     * @param _metadata descriptor for the account (pass in empty string if unchanged)
@@ -469,7 +469,7 @@ contract Allocations is AragonApp {
     {
         Account storage account = accounts[_accountId];
         Payout storage payout = account.payouts[_payoutId];
-        require(_candidateId < payout.supports.length, ERROR_NO_CANDIDATE); 
+        require(_candidateId < payout.supports.length, ERROR_NO_CANDIDATE);
 
         uint256 paid = _paid;
         uint256 totalSupport = _getTotalSupport(payout);


### PR DESCRIPTION
Third symbol in the dropdown:
![Screenshot from 2019-11-19 15-29-17](https://user-images.githubusercontent.com/19808076/69195777-7f6d2480-0ae1-11ea-8eca-bad40a7cc53a.png)

Displays correctly when editing budget:
![Screenshot from 2019-11-19 15-29-44](https://user-images.githubusercontent.com/19808076/69195780-8300ab80-0ae1-11ea-9f56-eba04fa6a069.png)
