### PR TITLE
Projects/FundForm: improve "can't be zero" errors

### DIFF
--- a/apps/projects/app/components/Panel/FundIssues/EditBounty.js
+++ b/apps/projects/app/components/Panel/FundIssues/EditBounty.js
@@ -31,6 +31,7 @@ const Deadline = styled.div`
 const EditBounty = ({
   bounty,
   issue,
+  onBlur,
   tokens,
   updateBounty,
 }) => {
@@ -73,6 +74,7 @@ const EditBounty = ({
               <AmountInput
                 name="amount"
                 value={bounty.payout}
+                onBlur={onBlur}
                 onChange={e => updateBounty({ payout: e.target.value })}
                 wide
               />
@@ -90,6 +92,7 @@ const EditBounty = ({
             <HoursInput
               name="hours"
               value={bounty.hours}
+              onBlur={onBlur}
               onChange={e => updateBounty({ hours: e.target.value })}
               wide
             />
@@ -131,6 +134,7 @@ const EditBounty = ({
 EditBounty.propTypes = {
   bounty: PropTypes.object,
   issue: issueShape,
+  onBlur: PropTypes.func,
   tokens: PropTypes.array.isRequired,
   updateBounty: PropTypes.func.isRequired,
 }

--- a/apps/projects/app/components/Panel/FundIssues/FundIssues.js
+++ b/apps/projects/app/components/Panel/FundIssues/FundIssues.js
@@ -227,6 +227,7 @@ const FundForm = ({
   const [ maxErrors, setMaxErrors ] = useState([])
   const [ zeroError, setZeroError ] = useState([])
   const [ dateError, setDateError ] = useState([])
+  const [ validate, setValidate ] = useState(false)
 
   useEffect(() => {
     setMaxErrors(tokens.reduce(
@@ -253,6 +254,7 @@ const FundForm = ({
   }, [ tokens, bounties ])
 
   useEffect(() => {
+    if (!validate) return
     const today = new Date()
     const zeroErrArray = []
     const dateErrArray = []
@@ -268,7 +270,7 @@ const FundForm = ({
       !!zeroErrArray.length ||
       !!dateErrArray.length
     )
-  }, [ bounties, description, maxErrors ])
+  }, [ validate, bounties, description, maxErrors ])
 
   return (
     <>
@@ -305,6 +307,7 @@ const FundForm = ({
                   issue={issue}
                   bounty={bounties[issue.id]}
                   tokens={tokens}
+                  onBlur={() => setValidate(true)}
                   updateBounty={updateBounty(issue.id)}
                 />
               ))}

--- a/apps/projects/app/components/Panel/FundIssues/FundIssues.js
+++ b/apps/projects/app/components/Panel/FundIssues/FundIssues.js
@@ -36,7 +36,9 @@ import {
 const ETHER_TOKEN_FAKE_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 const errorMessages = {
-  amount: () => 'Funding amounts must be greater than zero',
+  amount: ({ sayAmount, plural }) =>
+    (sayAmount ? `Funding amount${plural ? 's' : ''}` : 'Estimated hours') +
+    ' must be greater than zero',
   date: () => 'The deadline cannot be in the past',
   total: ({ inVault, sayTotal, symbol, total }) =>
     `The ${sayTotal ? 'total' : ''} funding amount of ${total} ${symbol} ` +
@@ -190,7 +192,14 @@ const BountyUpdate = ({
         />
       </Form>
       {maxError && <ErrorMessage text={errorMessages.total()} />}
-      {zeroError && <ErrorMessage text={errorMessages.amount()} />}
+      {zeroError &&
+        <ErrorMessage text={
+          errorMessages.amount({
+            sayAmount: bountySettings.fundingModel === 'Fixed',
+            plural: false,
+          })}
+        />
+      }
       {dateError && <ErrorMessage text={errorMessages.date()} />}
     </>
   )
@@ -213,6 +222,7 @@ const FundForm = ({
   descriptionChange,
   updateBounty,
 }) => {
+  const { appState: { bountySettings } } = useAragonApi()
   const [ submitDisabled, setSubmitDisabled ] = useState(true)
   const [ maxErrors, setMaxErrors ] = useState([])
   const [ zeroError, setZeroError ] = useState([])
@@ -247,7 +257,7 @@ const FundForm = ({
     const zeroErrArray = []
     const dateErrArray = []
     Object.values(bounties).forEach(bounty => {
-      if (bounty.payout === 0) zeroErrArray.push(bounty.issueId)
+      if (!bounty.payout) zeroErrArray.push(bounty.issueId)
       if (today > bounty.deadline) dateErrArray.push(bounty.issueId)
     })
     setZeroError(zeroErrArray)
@@ -305,7 +315,14 @@ const FundForm = ({
       {maxErrors.map((maxError, i) => (
         <ErrorMessage key={i} text={errorMessages.total(maxError)} />
       ))}
-      {!!zeroError.length && <ErrorMessage text={errorMessages.amount()} />}
+      {!!zeroError.length &&
+        <ErrorMessage text={
+          errorMessages.amount({
+            sayAmount: bountySettings.fundingModel === 'Fixed',
+            plural: issues.length > 1,
+          })}
+        />
+      }
       {!!dateError.length && <ErrorMessage text={errorMessages.date()} />}
     </>
   )


### PR DESCRIPTION
Fixes #1565

* improve wording based on `bountySettings.fundingModel`
* only show after an amount/hours input has blurred