### PR TITLE
Show SubmitWork option to issue owner only

### DIFF
--- a/apps/projects/app/components/Panel/ReviewApplication/ReviewApplication.js
+++ b/apps/projects/app/components/Panel/ReviewApplication/ReviewApplication.js
@@ -92,7 +92,7 @@ const ReviewApplication = ({ issue, requestIndex }) => {
         name="Applicant"
         items={issue.requestsData.map(request => request.user.login)}
         onChange={changeRequest}
-        selected={requestIndex}
+        selected={index}
         wide
       />
 
@@ -173,16 +173,14 @@ const ReviewApplication = ({ issue, requestIndex }) => {
               mode="negative"
               onClick={onReject}
               icon={<IconCross />}
-            >
-                Reject
-            </ReviewButton>
+              label="Reject"
+            />
             <ReviewButton
-              icon={<IconCheck />}
               mode="positive"
               onClick={onAccept}
-            >
-                Accept
-            </ReviewButton>
+              icon={<IconCheck />}
+              label="Accept"
+            />
           </ReviewRow>
         </React.Fragment>
       )}
@@ -216,9 +214,7 @@ const ApplicationDetails = styled.div`
   margin-top: 8px;
   margin-bottom: 14px;
 `
-const ReviewButton = styled(Button).attrs({
-  mode: 'strong',
-})`
+const ReviewButton = styled(Button)`
   width: 48%;
 `
 const ReviewRow = styled.div`

--- a/apps/projects/app/components/Shared/BountyContextMenu.js
+++ b/apps/projects/app/components/Shared/BountyContextMenu.js
@@ -3,24 +3,27 @@ import styled, { css } from 'styled-components'
 import { ContextMenuItem, GU, theme } from '@aragon/ui'
 import { usePanelManagement } from '../Panel'
 import { issueShape } from '../../utils/shapes.js'
-import { IconCoin, IconConnect, IconFile, IconView } from '@aragon/ui'
+import { IconCoin, IconConnect, IconFile, IconView, useTheme } from '@aragon/ui'
+import { useAragonApi } from '../../api-react'
 
 const BountyContextMenu = ({ issue }) => {
-  const { workStatus } = issue
+  const { workStatus, assignee } = issue
+  const { connectedAccount } = useAragonApi()
+
   const {
     allocateBounty,
-    editBounty,
     requestAssignment,
     reviewApplication,
     reviewWork,
     submitWork,
   } = usePanelManagement()
+  const theme = useTheme()
 
   return (
     <React.Fragment>
       {workStatus === undefined && (
         <Item onClick={() => allocateBounty([issue])}>
-          <IconCoin color={`${theme.surfaceIcon}`} />
+          <IconCoin color={`${theme.surfaceContent}`} />
           <ActionLabel>
             Fund Issue
           </ActionLabel>
@@ -28,18 +31,27 @@ const BountyContextMenu = ({ issue }) => {
       )}
       {workStatus === 'in-progress' && (
         <React.Fragment>
-          <Item onClick={() => submitWork(issue)}>
-            <IconConnect color={`${theme.surfaceIcon}`} />
+          {(connectedAccount === assignee) && (
+            <Item onClick={() => submitWork(issue)}>
+              <IconConnect color={`${theme.surfaceContent}`} />
+              <ActionLabel>
+                Submit Work
+              </ActionLabel>
+            </Item>
+          )}
+          <Item onClick={() => reviewApplication(issue)}>
+            <IconView color={`${theme.surfaceContent}`} />
             <ActionLabel>
-              Submit Work
+              View Applications ({issue.requestsData.length})
             </ActionLabel>
           </Item>
+
         </React.Fragment>
       )}
       {workStatus === 'review-work' && (
         <React.Fragment>
           <Item onClick={() => reviewWork(issue)}>
-            <IconView color={`${theme.surfaceIcon}`} />
+            <IconView color={`${theme.surfaceContent}`} />
             <ActionLabel>
               Review Work
             </ActionLabel>
@@ -49,7 +61,7 @@ const BountyContextMenu = ({ issue }) => {
       {workStatus === 'funded' && (
         <React.Fragment>
           <Item onClick={() => requestAssignment(issue)}>
-            <IconFile color={`${theme.surfaceIcon}`} />
+            <IconFile color={`${theme.surfaceContent}`} />
             <ActionLabel>
               Submit Application
             </ActionLabel>
@@ -63,20 +75,20 @@ const BountyContextMenu = ({ issue }) => {
       {workStatus === 'review-applicants' && (
         <React.Fragment>
           <Item onClick={() => requestAssignment(issue)}>
-            <IconFile color={`${theme.surfaceIcon}`} />
+            <IconFile color={`${theme.surfaceContent}`} />
             <ActionLabel>
               Submit Application
             </ActionLabel>
           </Item>
           <Item onClick={() => reviewApplication(issue)}>
-            <IconView color={`${theme.surfaceIcon}`} />
+            <IconView color={`${theme.surfaceContent}`} />
             <ActionLabel>
-              Review Application {issue.requestsData ? `(${issue.requestsData.length})` : ''}
+              Review Applications ({issue.requestsData.length})
             </ActionLabel>
           </Item>
           {/* Disabled since the contract doesn't allow updating the amount */}
           {/*<Item bordered onClick={() => editBounty([issue])}>*/}
-          {/*  <IconCoin color={`${theme.surfaceIcon}`} />*/}
+          {/*  <IconCoin color={`${theme.surfaceContent}`} />*/}
           {/*  <ActionLabel>*/}
           {/*    Update Funding*/}
           {/*  </ActionLabel>*/}


### PR DESCRIPTION
Achieved by comparing issue.assignee to connectedAccount from useAragonApi()
Apart from that:

1. Icons used theme.* colors, but theme itself wasn't available. Adding
it required updating all colors.

2. Issues in in-progress state should have had 'View Applications'
option - it got added. "View", because another ticket requests all
"Review"s to be changed to "View"s.

3. Accept/Reject buttons in Review Application panel were broken, screens before/after:
![Screenshot from 2019-11-21 16-53-11](https://user-images.githubusercontent.com/34452131/69358653-79b14380-0c87-11ea-9c95-e58a58e091e8.png)
![Screenshot from 2019-11-21 17-14-31](https://user-images.githubusercontent.com/34452131/69358654-7a49da00-0c87-11ea-91fb-b0fce19f69f4.png)
