### PR TITLE
Removed bounty info from IssueDetails

### DIFF
--- a/apps/projects/app/components/Content/IssueDetail/DetailsCard.js
+++ b/apps/projects/app/components/Content/IssueDetail/DetailsCard.js
@@ -19,7 +19,7 @@ import { formatDistance } from 'date-fns'
 const OpenedAgo = ({ date }) =>
   formatDistance(new Date(date), new Date(), { addSuffix: true })
 
-const dot = <span css="margin: 0px 10px">&middot;</span>
+const Dot = () => <span css="margin: 0px 10px">&middot;</span>
 
 const Title = ({ issue }) => {
   const theme = useTheme()
@@ -35,14 +35,17 @@ const Title = ({ issue }) => {
       <Text.Block size="xxlarge" style={{ marginBottom: 1.5 * GU + 'px' }}>
         {issue.title}
       </Text.Block>
-      <IssueTitleLink issue={issue}>
-        {dot}
-        <IconInfo
-          color={`${theme.positiveSurfaceContent}`}
-          css={`margin-top: -${.5 * GU}px; margin-right: ${.6 * GU}px`}
-        />
-        Opened <OpenedAgo date={issue.createdAt} />
-      </IssueTitleLink>
+      <div css="display: flex">
+        <IssueTitleLink issue={issue} />
+        <div css={`display: flex; align-items: center; margin-bottom: ${1.5 * GU}px`}>
+          <Dot />
+          <IconInfo
+            color={`${theme.positiveSurfaceContent}`}
+            css={`margin-top: -${.5 * GU}px; margin-right: ${.6 * GU}px`}
+          />
+          Opened <OpenedAgo date={issue.createdAt} />
+        </div>
+      </div>
     </div>
   )
 }

--- a/apps/projects/app/components/Content/IssueDetail/DetailsCard.js
+++ b/apps/projects/app/components/Content/IssueDetail/DetailsCard.js
@@ -1,8 +1,9 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import {
+  Box,
   ContextMenu,
   GU,
+  IconInfo,
   Tag,
   Text,
   useTheme,
@@ -15,147 +16,109 @@ import { issueShape } from '../../../utils/shapes.js'
 import { IssueTitleLink } from '../../Panel/PanelComponents'
 import { formatDistance } from 'date-fns'
 
-const DeadlineDistance = ({ date }) =>
+const OpenedAgo = ({ date }) =>
   formatDistance(new Date(date), new Date(), { addSuffix: true })
 
-const SummaryCell = ({ label, children, grid }) => (
+const dot = <span css="margin: 0px 10px">&middot;</span>
+
+const Title = ({ issue }) => {
+  const theme = useTheme()
+
+  return (
+    <div css={`
+      display: flex;
+      flex-direction: column;
+      flex-basis: 100%;
+      flex: 2;
+      margin-right: 20px;
+    `}>
+      <Text.Block size="xxlarge" style={{ marginBottom: 1.5 * GU + 'px' }}>
+        {issue.title}
+      </Text.Block>
+      <IssueTitleLink issue={issue}>
+        {dot}
+        <IconInfo
+          color={`${theme.positiveSurfaceContent}`}
+          css={`margin-top: -${.5 * GU}px; margin-right: ${.6 * GU}px`}
+        />
+        Opened <OpenedAgo date={issue.createdAt} />
+      </IssueTitleLink>
+    </div>
+  )
+}
+
+Title.propTypes = issueShape
+
+const Bounty = ({ issue }) => (
   <div css={`
     display: flex;
     flex-direction: column;
-    grid-area: ${grid};
-    overflow: hidden;
+    flex-basis: 100%;
+    flex: 0;
+    align-items: flex-end;
   `}>
-    <Label text={label} />
-    <div css={`
-      height: 100%;
-      display: flex;
-      align-items: center;
-      margin-top: ${2 * GU}px;
-    `}>
-      {children}
-    </div>
+    <ContextMenu>
+      <BountyContextMenu issue={issue} />
+    </ContextMenu>
+    {issue.balance > 0 && (
+      <Tag
+        css="padding: 10px; text-size: large; margin-top: 15px"
+        background={BOUNTY_BADGE_COLOR[issue.workStatus].bg}
+        color={BOUNTY_BADGE_COLOR[issue.workStatus].fg}
+      >
+        {issue.balance + ' ' + issue.symbol}
+      </Tag>
+    )}
   </div>
 )
-SummaryCell.propTypes = {
-  label: PropTypes.string.isRequired,
-  children: PropTypes.node.isRequired,
-  grid: PropTypes.string.isRequired,
-}
-
-const SummaryTable = ({ issue }) => (
-  <div css={`
-    margin-top: ${1.5 * GU}px;
-    ${issue.hasBounty && `
-      display: grid;
-      grid-template-rows: auto;
-      grid-gap: ${3 * GU}px;
-      grid-template-columns: 1fr 1fr;
-      grid-template-areas:
-        'deadline exp'
-        'description description';
-    `}
-  `}>
-    {issue.hasBounty &&
-      <>
-        <SummaryCell label="Deadline" grid="deadline">
-          <Text.Block>
-            <DeadlineDistance date={issue.deadline} />
-          </Text.Block>
-        </SummaryCell>
-        <SummaryCell label="Difficulty" grid="exp">
-          <Text.Block>
-            {issue.expLevel}
-          </Text.Block>
-        </SummaryCell>
-      </>
-    }
-    <SummaryCell label="Description" grid="description">
-      <Markdown
-        content={issue.body || 'No description available'}
-        style={{ marginBottom: 2 * GU + 'px' }}
-      />
-    </SummaryCell>
-  </div>
-)
-
-SummaryTable.propTypes = issueShape
+Bounty.propTypes = issueShape
 
 const DetailsCard = ({ issue }) => {
   const theme = useTheme()
 
   return (
-    <div css={`
-      flex: 0 1 auto;
-      text-align: left;
-      padding: 15px 30px;
-      background: ${theme.surface};
-      border: 1px solid ${theme.border};
-      border-radius: 3px;
-    `}>
+    <Box css={`padding-top: ${GU}px`}>
       <div css={`
         display: flex;
-        padding-top: 10px;
         justify-content: space-between;
-        margin-bottom: ${2 * GU};
       `}>
-        <div css={`
-          display: flex;
-          flex-direction: column;
-          flex-basis: 100%;
-          flex: 2;
-          margin-right: 20px;
-        `}>
-          <Text.Block size="xxlarge" style={{ marginBottom: (1.5 * GU) + 'px' }}>
-            {issue.title}
-          </Text.Block>
-          <IssueTitleLink issue={issue} />
-        </div>
-
-        <div css={`
-          display: flex;
-          flex-direction: column;
-          flex-basis: 100%;
-          flex: 0;
-          align-items: flex-end;
-        `}>
-          <ContextMenu>
-            <BountyContextMenu issue={issue} />
-          </ContextMenu>
-          {issue.balance > 0 && (
-            <Tag
-              css="padding: 10px; text-size: large; margin-top: 15px"
-              background={BOUNTY_BADGE_COLOR[issue.workStatus].bg}
-              color={BOUNTY_BADGE_COLOR[issue.workStatus].fg}
-            >
-              {issue.balance + ' ' + issue.symbol}
-            </Tag>
-          )}
-        </div>
-
+        <Title issue={issue} />
+        <Bounty issue={issue} />
       </div>
 
-      <SummaryTable issue={issue} />
-
-      <Text size="small" color={`${theme.surfaceContentSecondary}`}>
-        {issue.labels.totalCount
-          ? issue.labels.edges.map(label => (
+      {issue.labels.totalCount > 0 && (
+        <div css={`margin-bottom: ${2 * GU}px`}>
+          {issue.labels.edges.map(label => (
             <Tag
               key={label.node.id}
-              style={{ marginRight: '5px', marginTop: '20px' }}
+              css={`margin-right: ${.6 * GU}px`}
               background={'#' + label.node.color + '99'}
               color={`${theme.content}`}
               uppercase={false}
             >
               {label.node.name}
             </Tag>
-          ))
-          : ''}
-      </Text>
-    </div>
+          ))}
+        </div>
+      )}
+
+      <Label text="Description" />
+      <div css={`
+        height: 100%;
+        display: flex;
+        align-items: center;
+        margin-top: ${GU}px;
+      `}>
+        <Markdown
+          content={issue.body || 'No description available'}
+          style={{ marginBottom: 2 * GU + 'px' }}
+        />
+      </div>
+
+    </Box>
   )
 }
 
 DetailsCard.propTypes = issueShape
 
-// eslint-disable-next-line import/no-unused-modules
 export default DetailsCard

--- a/apps/projects/app/components/Panel/PanelComponents.js
+++ b/apps/projects/app/components/Panel/PanelComponents.js
@@ -4,28 +4,29 @@ import { Text, GU, useTheme, Link } from '@aragon/ui'
 import { IconGitHub } from '../Shared'
 import { issueShape } from '../../utils/shapes.js'
 
-export const IssueTitleLink = ({ issue }) => {
+export const IssueTitleLink = ({ children, issue }) => {
   const theme = useTheme()
 
   return (
-    <Link
-      href={issue.url}
-      target="_blank"
-      style={{ textDecoration: 'none' }}
-    >
-      <IssueLinkRow>
-        <div css="margin-top: 2px">
-          <IconGitHub
-            color={`${theme.surfaceContentSecondary}`}
-            width="16px"
-            height="16px"
-          />
-        </div>
+    <IssueLinkRow>
+      <div css={`margin-top: ${.5 * GU}px`}>
+        <IconGitHub
+          color={`${theme.surfaceContentSecondary}`}
+          width="16px"
+          height="16px"
+        />
+      </div>
+      <Link
+        href={issue.url}
+        target="_blank"
+        style={{ textDecoration: 'none' }}
+      >
         <Text css="margin-left: 6px" color={`${theme.link}`}>
           {issue.repo} #{issue.number}
         </Text>
-      </IssueLinkRow>
-    </Link>
+      </Link>
+      {children}
+    </IssueLinkRow>
   )
 }
 IssueTitleLink.propTypes = issueShape

--- a/apps/projects/app/components/Panel/PanelComponents.js
+++ b/apps/projects/app/components/Panel/PanelComponents.js
@@ -4,7 +4,7 @@ import { Text, GU, useTheme, Link } from '@aragon/ui'
 import { IconGitHub } from '../Shared'
 import { issueShape } from '../../utils/shapes.js'
 
-export const IssueTitleLink = ({ children, issue }) => {
+export const IssueTitleLink = ({ issue }) => {
   const theme = useTheme()
 
   return (
@@ -25,7 +25,6 @@ export const IssueTitleLink = ({ children, issue }) => {
           {issue.repo} #{issue.number}
         </Text>
       </Link>
-      {children}
     </IssueLinkRow>
   )
 }


### PR DESCRIPTION
Because all the info now lives in Bounty widget (former Status widget).
Also: cleaned up IssueDetails component - a lot of code was no longer
required. PanelComponents got touched, because Issue Title is a very
reusable component - in all panels, and issue details as well.
What needed to be done was restricting Link to only issue's ID
(it used to be whole div - including GH icon), and adding extra
children prop to the component, so I could do this:
```
<IssueTitleLink issue={issue}>
   {dot}
   <IconInfo
...
```
as per design. One note: we only download open issues right now.
What happens when an issue a bounty is attached to becomes closed...
That requires a separate ticket.