### PR TITLE
Minimum Viable AragonRouter

### DIFF
--- a/apps/address-book/package.json
+++ b/apps/address-book/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@aragon/api": "2.0.0-beta.8",
-    "@aragon/api-react": "2.0.0-beta.6",
+    "@aragon/api-react": "2.0.0-beta.8",
     "@aragon/ui": "^1.0.0-alpha.26",
     "axios": "^0.18.0",
     "ipfs-http-client": "29.1.0",

--- a/apps/address-book/package.json
+++ b/apps/address-book/package.json
@@ -34,13 +34,14 @@
     "@aragon/api-react": "2.0.0-beta.8",
     "@aragon/ui": "^1.0.0-alpha.26",
     "axios": "^0.18.0",
+    "date-fns": "2.0.0-alpha.22",
     "ipfs-http-client": "29.1.0",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
+    "react-router": "^5.1.2",
     "styled-components": "4.1.3",
-    "web3-utils": "^1.0.0",
-    "date-fns": "2.0.0-alpha.22"
+    "web3-utils": "^1.0.0"
   },
   "devDependencies": {
     "@aragon/test-helpers": "^1.0.1",
@@ -65,6 +66,7 @@
     "eth-gas-reporter": "0.1.12",
     "ethereumjs-abi": "0.6.5",
     "ganache-cli": "6.1.8",
+    "history": "^4.10.1",
     "homedir": "^0.6.0",
     "lint-staged": "^9.2.0",
     "parcel-bundler": "1.12.3",

--- a/apps/address-book/package.json
+++ b/apps/address-book/package.json
@@ -40,6 +40,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-router": "^5.1.2",
+    "react-router-dom": "^5.1.2",
     "styled-components": "4.1.3",
     "web3-utils": "^1.0.0"
   },

--- a/apps/allocations/app/api-react.js
+++ b/apps/allocations/app/api-react.js
@@ -105,6 +105,6 @@ const functions = process.env.NODE_ENV !== 'production' && ((appState, setAppSta
   }),
 }))
 
-const { useAragonApi } = buildStubbedApiReact({ initialState, functions })
+const { AragonApi, useAragonApi } = buildStubbedApiReact({ initialState, functions })
 
-export { useAragonApi }
+export { AragonApi, useAragonApi }

--- a/apps/allocations/app/api-react.js
+++ b/apps/allocations/app/api-react.js
@@ -105,6 +105,6 @@ const functions = process.env.NODE_ENV !== 'production' && ((appState, setAppSta
   }),
 }))
 
-const { AragonApi, useAragonApi } = buildStubbedApiReact({ initialState, functions })
+const { AragonApi, AragonRouter, useAragonApi } = buildStubbedApiReact({ initialState, functions })
 
-export { AragonApi, useAragonApi }
+export { AragonApi, AragonRouter, useAragonApi }

--- a/apps/allocations/app/components/App/App.js
+++ b/apps/allocations/app/components/App/App.js
@@ -1,42 +1,21 @@
 import React from 'react'
 import { useAragonApi } from '../../api-react'
-import { Button, Header, IconPlus, Main, SidePanel, SyncIndicator } from '@aragon/ui'
+import { Main, SidePanel, SyncIndicator } from '@aragon/ui'
 
 import { IdentityProvider } from '../LocalIdentityBadge/IdentityManager'
-import { Empty } from '../Card'
-import { NewBudget } from '../Panel'
-import { AllocationsHistory, Budgets } from '.'
+import { Overview } from '.'
 import { usePanel } from '../../context/Panel'
 
 const App = () => {
   const { api, appState } = useAragonApi()
-  const { allocations = [], budgets = [], isSyncing = true } = appState
+  const { isSyncing = true } = appState
 
   const { panel, panelOpen, setPanel } = usePanel()
-
-  const saveBudget = ({ amount, name, token }) => {
-    api
-      .newAccount(
-        name,             // _metadata
-        token.address,    // _token
-        true,             // hasBudget
-        amount
-      )
-      .toPromise()
-    setPanel(null)
-  }
 
   // TODO: Fix this
   // eslint-disable-next-line
   const onExecutePayout = (accountId, payoutId) => {
     api.runPayout(accountId, payoutId).toPromise()
-  }
-
-  const onNewBudget = () => {
-    setPanel({
-      content: NewBudget,
-      data: { heading: 'New budget', saveBudget },
-    })
   }
 
   const handleResolveLocalIdentity = address =>
@@ -53,27 +32,8 @@ const App = () => {
         onResolve={handleResolveLocalIdentity}
         onShowLocalIdentityModal={handleShowLocalIdentityModal}
       >
-        {budgets.length === 0
-          ? <Empty action={onNewBudget} isSyncing={isSyncing} />
-          : (
-            <React.Fragment>
-              <Header
-                primary="Allocations"
-                secondary={
-                  <Button
-                    mode="strong"
-                    icon={<IconPlus />}
-                    onClick={onNewBudget}
-                    label="New budget"
-                  />
-                }
-              />
-              <Budgets />
-              <SyncIndicator visible={isSyncing} />
-            </React.Fragment>
-          )
-        }
-        { !!allocations.length && <AllocationsHistory allocations={allocations} /> }
+        <Overview />
+        <SyncIndicator visible={isSyncing} />
         <SidePanel
           title={(panel && panel.data.heading) || ''}
           opened={panelOpen}

--- a/apps/allocations/app/components/App/App.js
+++ b/apps/allocations/app/components/App/App.js
@@ -9,12 +9,22 @@ import { AllocationsHistory, Budgets } from '.'
 import { Deactivate } from '../Modal'
 
 const App = () => {
-  const [ panel, setPanel ] = useState(null)
+  const [ panel, setPanelRaw ] = useState(null)
   const [ panelOpen, setPanelOpen ] = useState(false)
   const [ isModalVisible, setModalVisible ] = useState(false)
   const [ currentBudgetId, setCurrentBudgetId ] = useState('')
   const { api, appState } = useAragonApi()
   const { allocations = [], budgets = [], isSyncing = true } = appState
+
+  const setPanel = args => {
+    if (args) {
+      setPanelRaw(args)
+      setPanelOpen(true)
+    } else {
+      setPanelOpen(false)
+      setTimeout(() => setPanelRaw(args), 500)
+    }
+  }
 
   const saveBudget = ({ id, amount, name, token }) => {
     if (id) {
@@ -29,7 +39,7 @@ const App = () => {
         )
         .toPromise()
     }
-    closePanel()
+    setPanel(null)
   }
 
   const onSubmitAllocation = ({
@@ -54,8 +64,7 @@ const App = () => {
       period,
       balance, // amount
     ).toPromise()
-    closePanel()
-
+    setPanel(null)
   }
 
   const onSubmitDeactivate = () => { // TODO id => {
@@ -73,7 +82,6 @@ const App = () => {
       content: NewBudget,
       data: { heading: 'New budget', saveBudget },
     })
-    setPanelOpen(true)
   }
 
   const onNewAllocation = (budgetId) => {
@@ -88,7 +96,6 @@ const App = () => {
         balances,
       },
     })
-    setPanelOpen(true)
   }
 
   const onEdit = id => {
@@ -101,7 +108,6 @@ const App = () => {
         editingBudget,
       },
     })
-    setPanelOpen(true)
   }
 
   const onDeactivate = id => {
@@ -111,11 +117,6 @@ const App = () => {
 
   const onReactivate = () => { // TODO id => {
     //api.reactivateBudget(id)
-  }
-
-  const closePanel = () => {
-    setPanelOpen(false)
-    setPanel(null)
   }
 
   const closeModal = () => {
@@ -173,7 +174,7 @@ const App = () => {
         <SidePanel
           title={(panel && panel.data.heading) || ''}
           opened={panelOpen}
-          onClose={closePanel}
+          onClose={() => setPanel(null)}
         >
           {panel && <PanelContent {...panel.data} />}
         </SidePanel>

--- a/apps/allocations/app/components/App/App.js
+++ b/apps/allocations/app/components/App/App.js
@@ -1,9 +1,10 @@
 import React from 'react'
+import { Route } from 'react-router'
 import { useAragonApi } from '../../api-react'
 import { Main, SidePanel, SyncIndicator } from '@aragon/ui'
 
 import { IdentityProvider } from '../LocalIdentityBadge/IdentityManager'
-import { Overview } from '.'
+import { BudgetDetail, Overview } from '.'
 import { usePanel } from '../../context/Panel'
 
 const App = () => {
@@ -32,7 +33,12 @@ const App = () => {
         onResolve={handleResolveLocalIdentity}
         onShowLocalIdentityModal={handleShowLocalIdentityModal}
       >
-        <Overview />
+        <Route path="/" exact>
+          <Overview />
+        </Route>
+        <Route path="/budgets/:id" exact>
+          <BudgetDetail />
+        </Route>
         <SyncIndicator visible={isSyncing} />
         <SidePanel
           title={(panel && panel.data.heading) || ''}

--- a/apps/allocations/app/components/App/App.js
+++ b/apps/allocations/app/components/App/App.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Route } from 'react-router'
+import { Route } from 'react-router-dom'
 import { useAragonApi } from '../../api-react'
 import { Main, SidePanel, SyncIndicator } from '@aragon/ui'
 

--- a/apps/allocations/app/components/App/App.js
+++ b/apps/allocations/app/components/App/App.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { useAragonApi } from '../../api-react'
 import { Button, Header, IconPlus, Main, SidePanel, SyncIndicator } from '@aragon/ui'
 
@@ -6,22 +6,13 @@ import { IdentityProvider } from '../LocalIdentityBadge/IdentityManager'
 import { Empty } from '../Card'
 import { NewBudget } from '../Panel'
 import { AllocationsHistory, Budgets } from '.'
+import { usePanel } from '../../context/Panel'
 
 const App = () => {
-  const [ panel, setPanelRaw ] = useState(null)
-  const [ panelOpen, setPanelOpen ] = useState(false)
   const { api, appState } = useAragonApi()
   const { allocations = [], budgets = [], isSyncing = true } = appState
 
-  const setPanel = args => {
-    if (args) {
-      setPanelRaw(args)
-      setPanelOpen(true)
-    } else {
-      setPanelOpen(false)
-      setTimeout(() => setPanelRaw(args), 500)
-    }
-  }
+  const { panel, panelOpen, setPanel } = usePanel()
 
   const saveBudget = ({ amount, name, token }) => {
     api
@@ -77,7 +68,7 @@ const App = () => {
                   />
                 }
               />
-              <Budgets setPanel={setPanel} />
+              <Budgets />
               <SyncIndicator visible={isSyncing} />
             </React.Fragment>
           )

--- a/apps/allocations/app/components/App/BudgetDetail.js
+++ b/apps/allocations/app/components/App/BudgetDetail.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import { Redirect, useParams } from 'react-router'
+import { useAragonApi } from '../../api-react'
+
+export default function BudgetDetail() {
+  const { appState } = useAragonApi()
+  const { id } = useParams()
+  const budget = appState.budgets.find(b => b.id === id)
+
+  if (!budget) {
+    return <Redirect to="/" />
+  }
+
+  return JSON.stringify(budget)
+}

--- a/apps/allocations/app/components/App/BudgetDetail.js
+++ b/apps/allocations/app/components/App/BudgetDetail.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Redirect, useParams } from 'react-router'
+import { Redirect, useParams } from 'react-router-dom'
 import { useAragonApi } from '../../api-react'
 
 export default function BudgetDetail() {

--- a/apps/allocations/app/components/App/Budgets.js
+++ b/apps/allocations/app/components/App/Budgets.js
@@ -1,45 +1,125 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useState } from 'react'
 import styled from 'styled-components'
 
+import { useAragonApi } from '../../api-react'
 import { GU } from '@aragon/ui'
 
+import { NewAllocation, NewBudget } from '../Panel'
 import { Budget } from '../Card'
+import { Deactivate } from '../Modal'
 
-const Budgets = ({
-  budgets,
-  onNewAllocation,
-  onEdit,
-  onDeactivate,
-  onReactivate,
-}) => {
+const Budgets = ({ setPanel }) => {
+  const { api, appState } = useAragonApi()
+  const { budgets = [] } = appState
+  const [ isModalVisible, setModalVisible ] = useState(false)
+  const [ currentBudgetId, setCurrentBudgetId ] = useState('')
+
+  const closeModal = () => {
+    setModalVisible(false)
+    setCurrentBudgetId('')
+  }
+
+  const saveBudget = ({ id, amount, name }) => {
+    api.setBudget(id, amount, name).toPromise()
+    setPanel(null)
+  }
+
+  const onSubmitAllocation = ({
+    addresses,
+    description,
+    budgetId,
+    period = 0,
+    balance,
+  }) => {
+    const emptyIntArray = new Array(addresses.length).fill(0)
+    api.setDistribution(
+      addresses,
+      emptyIntArray, // unused
+      emptyIntArray, // unused
+      '', // unused
+      description,
+      emptyIntArray, // unused
+      emptyIntArray, // unused
+      budgetId, // account or allocation id...budgetId
+      '1', // recurrences, 1 for now
+      Math.floor(new Date().getTime()/1000), // startTime, now for now
+      period,
+      balance, // amount
+    ).toPromise()
+    setPanel(null)
+  }
+
+  const onNewAllocation = budgetId => {
+    const { balances } = appState
+    setPanel({
+      content: NewAllocation,
+      data: {
+        budgetId,
+        heading: 'New allocation',
+        onSubmitAllocation,
+        budgets,
+        balances,
+      },
+    })
+  }
+
+  const onEdit = id => {
+    const editingBudget = budgets.find(budget => budget.id === id)
+    setPanel({
+      content: NewBudget,
+      data: {
+        heading: 'Edit budget',
+        saveBudget,
+        editingBudget,
+      },
+    })
+  }
+
+  const onDeactivate = id => {
+    setModalVisible(true)
+    setCurrentBudgetId(id)
+  }
+
+  const onSubmitDeactivate = () => { // TODO id => {
+    closeModal()
+  }
+
+  const onReactivate = () => { // TODO id => {
+    //api.reactivateBudget(id)
+  }
+
   return (
-    <StyledBudgets>
-      {budgets.map(({ remaining, hasBudget, id, name, amount, token }) => (
-        <Budget
-          key={id}
-          id={id}
-          name={name}
-          amount={amount}
-          token={token}
-          remaining={remaining}
-          inactive={!hasBudget}
-          onNewAllocation={onNewAllocation}
-          onEdit={onEdit}
-          onDeactivate={onDeactivate}
-          onReactivate={onReactivate}
-        />
-      ))}
-    </StyledBudgets>
+    <>
+      <StyledBudgets>
+        {budgets.map(({ amount, hasBudget, id, name, remaining, token }) => (
+          <Budget
+            key={id}
+            id={id}
+            name={name}
+            amount={amount}
+            token={token}
+            remaining={remaining}
+            inactive={!hasBudget}
+            onNewAllocation={onNewAllocation}
+            onEdit={onEdit}
+            onDeactivate={onDeactivate}
+            onReactivate={onReactivate}
+          />
+        ))}
+      </StyledBudgets>
+      <Deactivate
+        visible={isModalVisible}
+        budgetId={currentBudgetId}
+        onClose={closeModal}
+        onSubmit={onSubmitDeactivate}
+      />
+    </>
   )
 }
 
 Budgets.propTypes = {
-  budgets: PropTypes.arrayOf(PropTypes.object).isRequired,
-  onNewAllocation: PropTypes.func.isRequired,
-  onEdit: PropTypes.func.isRequired,
-  onDeactivate: PropTypes.func.isRequired,
-  onReactivate: PropTypes.func.isRequired,
+  setPanel: PropTypes.func.isRequired,
 }
 
 const StyledBudgets = styled.div`

--- a/apps/allocations/app/components/App/Budgets.js
+++ b/apps/allocations/app/components/App/Budgets.js
@@ -1,0 +1,129 @@
+import React, { useState } from 'react'
+import styled from 'styled-components'
+
+import { useAragonApi } from '../../api-react'
+import { GU } from '@aragon/ui'
+
+import { NewAllocation, NewBudget } from '../Panel'
+import { Budget } from '../Card'
+import { Deactivate } from '../Modal'
+import { usePanel } from '../../context/Panel'
+
+const Budgets = () => {
+  const { api, appState } = useAragonApi()
+  const { budgets = [] } = appState
+  const [ isModalVisible, setModalVisible ] = useState(false)
+  const [ currentBudgetId, setCurrentBudgetId ] = useState('')
+  const { setPanel } = usePanel()
+
+  const closeModal = () => {
+    setModalVisible(false)
+    setCurrentBudgetId('')
+  }
+
+  const saveBudget = ({ id, amount, name }) => {
+    api.setBudget(id, amount, name).toPromise()
+    setPanel(null)
+  }
+
+  const onSubmitAllocation = ({
+    addresses,
+    description,
+    budgetId,
+    period = 0,
+    balance,
+  }) => {
+    const emptyIntArray = new Array(addresses.length).fill(0)
+    api.setDistribution(
+      addresses,
+      emptyIntArray, // unused
+      emptyIntArray, // unused
+      '', // unused
+      description,
+      emptyIntArray, // unused
+      emptyIntArray, // unused
+      budgetId, // account or allocation id...budgetId
+      '1', // recurrences, 1 for now
+      Math.floor(new Date().getTime()/1000), // startTime, now for now
+      period,
+      balance, // amount
+    ).toPromise()
+    setPanel(null)
+  }
+
+  const onNewAllocation = budgetId => {
+    const { balances } = appState
+    setPanel({
+      content: NewAllocation,
+      data: {
+        budgetId,
+        heading: 'New allocation',
+        onSubmitAllocation,
+        budgets,
+        balances,
+      },
+    })
+  }
+
+  const onEdit = id => {
+    const editingBudget = budgets.find(budget => budget.id === id)
+    setPanel({
+      content: NewBudget,
+      data: {
+        heading: 'Edit budget',
+        saveBudget,
+        editingBudget,
+      },
+    })
+  }
+
+  const onDeactivate = id => {
+    setModalVisible(true)
+    setCurrentBudgetId(id)
+  }
+
+  const onSubmitDeactivate = () => { // TODO id => {
+    closeModal()
+  }
+
+  const onReactivate = () => { // TODO id => {
+    //api.reactivateBudget(id)
+  }
+
+  return (
+    <>
+      <StyledBudgets>
+        {budgets.map(({ amount, hasBudget, id, name, remaining, token }) => (
+          <Budget
+            key={id}
+            id={id}
+            name={name}
+            amount={amount}
+            token={token}
+            remaining={remaining}
+            inactive={!hasBudget}
+            onNewAllocation={onNewAllocation}
+            onEdit={onEdit}
+            onDeactivate={onDeactivate}
+            onReactivate={onReactivate}
+          />
+        ))}
+      </StyledBudgets>
+      <Deactivate
+        visible={isModalVisible}
+        budgetId={currentBudgetId}
+        onClose={closeModal}
+        onSubmit={onSubmitDeactivate}
+      />
+    </>
+  )
+}
+
+const StyledBudgets = styled.div`
+  display: grid;
+  grid-gap: ${2 * GU}px;
+  grid-template-columns: repeat(auto-fill, minmax(${27 * GU}px, 1fr));
+  margin-bottom: ${2 * GU}px;
+`
+
+export default Budgets

--- a/apps/allocations/app/components/App/Budgets.js
+++ b/apps/allocations/app/components/App/Budgets.js
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import styled from 'styled-components'
 
@@ -8,12 +7,14 @@ import { GU } from '@aragon/ui'
 import { NewAllocation, NewBudget } from '../Panel'
 import { Budget } from '../Card'
 import { Deactivate } from '../Modal'
+import { usePanel } from '../../context/Panel'
 
-const Budgets = ({ setPanel }) => {
+const Budgets = () => {
   const { api, appState } = useAragonApi()
   const { budgets = [] } = appState
   const [ isModalVisible, setModalVisible ] = useState(false)
   const [ currentBudgetId, setCurrentBudgetId ] = useState('')
+  const { setPanel } = usePanel()
 
   const closeModal = () => {
     setModalVisible(false)
@@ -116,10 +117,6 @@ const Budgets = ({ setPanel }) => {
       />
     </>
   )
-}
-
-Budgets.propTypes = {
-  setPanel: PropTypes.func.isRequired,
 }
 
 const StyledBudgets = styled.div`

--- a/apps/allocations/app/components/App/Overview.js
+++ b/apps/allocations/app/components/App/Overview.js
@@ -1,40 +1,27 @@
-import React, { useState } from 'react'
-import styled from 'styled-components'
+import React from 'react'
 
 import { useAragonApi } from '../../api-react'
-import { Button, GU, Header, IconPlus } from '@aragon/ui'
+import { Button, Header, IconPlus } from '@aragon/ui'
 
-import { AllocationsHistory } from '.'
-import { NewAllocation, NewBudget } from '../Panel'
-import { Budget, Empty } from '../Card'
-import { Deactivate } from '../Modal'
+import { AllocationsHistory, Budgets } from '.'
+import { NewBudget } from '../Panel'
+import { Empty } from '../Card'
 import { usePanel } from '../../context/Panel'
 
 const Overview = () => {
   const { api, appState } = useAragonApi()
   const { allocations = [], budgets = [], isSyncing = true } = appState
-  const [ isModalVisible, setModalVisible ] = useState(false)
-  const [ currentBudgetId, setCurrentBudgetId ] = useState('')
   const { setPanel } = usePanel()
 
-  const closeModal = () => {
-    setModalVisible(false)
-    setCurrentBudgetId('')
-  }
-
-  const saveBudget = ({ id, amount, name, token }) => {
-    if (id) {
-      api.setBudget(id, amount, name).toPromise()
-    } else {
-      api
-        .newAccount(
-          name,             // _metadata
-          token.address,    // _token
-          true,             // hasBudget
-          amount
-        )
-        .toPromise()
-    }
+  const saveBudget = ({ amount, name, token }) => {
+    api
+      .newAccount(
+        name,             // _metadata
+        token.address,    // _token
+        true,             // hasBudget
+        amount
+      )
+      .toPromise()
     setPanel(null)
   }
 
@@ -43,70 +30,6 @@ const Overview = () => {
       content: NewBudget,
       data: { heading: 'New budget', saveBudget },
     })
-  }
-
-  const onSubmitAllocation = ({
-    addresses,
-    description,
-    budgetId,
-    period = 0,
-    balance,
-  }) => {
-    const emptyIntArray = new Array(addresses.length).fill(0)
-    api.setDistribution(
-      addresses,
-      emptyIntArray, // unused
-      emptyIntArray, // unused
-      '', // unused
-      description,
-      emptyIntArray, // unused
-      emptyIntArray, // unused
-      budgetId, // account or allocation id...budgetId
-      '1', // recurrences, 1 for now
-      Math.floor(new Date().getTime()/1000), // startTime, now for now
-      period,
-      balance, // amount
-    ).toPromise()
-    setPanel(null)
-  }
-
-  const onNewAllocation = budgetId => {
-    const { balances } = appState
-    setPanel({
-      content: NewAllocation,
-      data: {
-        budgetId,
-        heading: 'New allocation',
-        onSubmitAllocation,
-        budgets,
-        balances,
-      },
-    })
-  }
-
-  const onEdit = id => {
-    const editingBudget = budgets.find(budget => budget.id === id)
-    setPanel({
-      content: NewBudget,
-      data: {
-        heading: 'Edit budget',
-        saveBudget,
-        editingBudget,
-      },
-    })
-  }
-
-  const onDeactivate = id => {
-    setModalVisible(true)
-    setCurrentBudgetId(id)
-  }
-
-  const onSubmitDeactivate = () => { // TODO id => {
-    closeModal()
-  }
-
-  const onReactivate = () => { // TODO id => {
-    //api.reactivateBudget(id)
   }
 
   if (budgets.length === 0) {
@@ -126,39 +49,10 @@ const Overview = () => {
           />
         }
       />
-      <StyledBudgets>
-        {budgets.map(({ amount, hasBudget, id, name, remaining, token }) => (
-          <Budget
-            key={id}
-            id={id}
-            name={name}
-            amount={amount}
-            token={token}
-            remaining={remaining}
-            inactive={!hasBudget}
-            onNewAllocation={onNewAllocation}
-            onEdit={onEdit}
-            onDeactivate={onDeactivate}
-            onReactivate={onReactivate}
-          />
-        ))}
-      </StyledBudgets>
-      <Deactivate
-        visible={isModalVisible}
-        budgetId={currentBudgetId}
-        onClose={closeModal}
-        onSubmit={onSubmitDeactivate}
-      />
+      <Budgets />
       { !!allocations.length && <AllocationsHistory allocations={allocations} /> }
     </>
   )
 }
-
-const StyledBudgets = styled.div`
-  display: grid;
-  grid-gap: ${2 * GU}px;
-  grid-template-columns: repeat(auto-fill, minmax(${27 * GU}px, 1fr));
-  margin-bottom: ${2 * GU}px;
-`
 
 export default Overview

--- a/apps/allocations/app/components/App/index.js
+++ b/apps/allocations/app/components/App/index.js
@@ -1,3 +1,4 @@
 export { default as AllocationsHistory } from './AllocationsHistory'
+export { default as BudgetDetail } from './BudgetDetail'
 export { default as Budgets } from './Budgets'
 export { default as Overview } from './Overview'

--- a/apps/allocations/app/components/App/index.js
+++ b/apps/allocations/app/components/App/index.js
@@ -1,2 +1,3 @@
-export { default as Overview } from './Overview'
 export { default as AllocationsHistory } from './AllocationsHistory'
+export { default as Budgets } from './Budgets'
+export { default as Overview } from './Overview'

--- a/apps/allocations/app/components/App/index.js
+++ b/apps/allocations/app/components/App/index.js
@@ -1,2 +1,2 @@
-export { default as Budgets } from './Budgets'
+export { default as Overview } from './Overview'
 export { default as AllocationsHistory } from './AllocationsHistory'

--- a/apps/allocations/app/components/Card/Budget.js
+++ b/apps/allocations/app/components/Card/Budget.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
 import BigNumber from 'bignumber.js'
+import { Link } from 'react-router-dom'
 import { displayCurrency } from '../../utils/helpers'
 
 import {
@@ -48,6 +49,7 @@ const Budget = ({
   if (inactive) {
     return (
       <Wrapper
+        id={id}
         name={name}
         theme={theme}
         menu={
@@ -66,6 +68,7 @@ const Budget = ({
 
   return (
     <Wrapper
+      id={id}
       name={name}
       theme={theme}
       menu={
@@ -120,14 +123,18 @@ Budget.propTypes = {
   onReactivate: PropTypes.func.isRequired,
 }
 
-const Wrapper = ({ children, name, theme, menu }) => (
+const Wrapper = ({ children, id, name, theme, menu }) => (
   <StyledCard theme={theme}>
     <MenuContainer>
       <ContextMenu>
         {menu}
       </ContextMenu>
     </MenuContainer>
-    <CardTitle theme={theme}>{name}</CardTitle>
+    <CardTitle theme={theme}>
+      <Link to={`/budgets/${id}`}>
+        {name}
+      </Link>
+    </CardTitle>
     <StatsContainer>
       <StyledStats>
         {children}
@@ -138,6 +145,7 @@ const Wrapper = ({ children, name, theme, menu }) => (
 
 Wrapper.propTypes = {
   children: PropTypes.node.isRequired,
+  id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   theme: PropTypes.object.isRequired,
   menu: PropTypes.node.isRequired,

--- a/apps/allocations/app/context/Panel.js
+++ b/apps/allocations/app/context/Panel.js
@@ -1,0 +1,33 @@
+import React from 'react'
+
+const PanelContext = React.createContext()
+
+export function usePanel() {
+  const context = React.useContext(PanelContext)
+  if (!context) {
+    throw new Error('usePanel must be used within a PanelProvider')
+  }
+  return context
+}
+
+export function PanelProvider(props) {
+  const [ panel, setPanelRaw ] = React.useState(null)
+  const [ panelOpen, setPanelOpen ] = React.useState(false)
+
+  const setPanel = React.useCallback(args => {
+    if (args) {
+      setPanelRaw(args)
+      setPanelOpen(true)
+    } else {
+      setPanelOpen(false)
+      setTimeout(() => setPanelRaw(args), 500)
+    }
+  }, [])
+
+  const value = React.useMemo(() => {
+    return { panel, panelOpen, setPanel }
+  }, [ panel, panelOpen ])
+
+  return <PanelContext.Provider value={value} {...props} />
+}
+

--- a/apps/allocations/app/index.js
+++ b/apps/allocations/app/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-unused-modules */
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { AragonApi } from '@aragon/api-react'
+import { AragonApi } from './api-react'
 import appStateReducer from './app-state-reducer'
 import App from './components/App/App'
 import { PanelProvider } from './context/Panel'

--- a/apps/allocations/app/index.js
+++ b/apps/allocations/app/index.js
@@ -4,11 +4,14 @@ import ReactDOM from 'react-dom'
 import { AragonApi } from '@aragon/api-react'
 import appStateReducer from './app-state-reducer'
 import App from './components/App/App'
+import { PanelProvider } from './context/Panel'
 
 // TODO: Profile App with React.StrictMode, perf and why-did-you-update, apply memoization
 ReactDOM.render(
   <AragonApi reducer={appStateReducer}>
-    <App />
+    <PanelProvider>
+      <App />
+    </PanelProvider>
   </AragonApi>,
   document.querySelector('#allocations')
 )

--- a/apps/allocations/app/index.js
+++ b/apps/allocations/app/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-unused-modules */
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { AragonApi } from './api-react'
+import { AragonApi, AragonRouter } from './api-react'
 import appStateReducer from './app-state-reducer'
 import App from './components/App/App'
 import { PanelProvider } from './context/Panel'
@@ -9,9 +9,11 @@ import { PanelProvider } from './context/Panel'
 // TODO: Profile App with React.StrictMode, perf and why-did-you-update, apply memoization
 ReactDOM.render(
   <AragonApi reducer={appStateReducer}>
-    <PanelProvider>
-      <App />
-    </PanelProvider>
+    <AragonRouter>
+      <PanelProvider>
+        <App />
+      </PanelProvider>
+    </AragonRouter>
   </AragonApi>,
   document.querySelector('#allocations')
 )

--- a/apps/allocations/package.json
+++ b/apps/allocations/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@aragon/api": "2.0.0-beta.8",
-    "@aragon/api-react": "2.0.0-beta.6",
+    "@aragon/api-react": "2.0.0-beta.8",
     "@aragon/apps-vault": "4.1.0",
     "@aragon/os": "4.2.0",
     "@aragon/ui": "1.0.0-alpha.26",

--- a/apps/allocations/package.json
+++ b/apps/allocations/package.json
@@ -37,12 +37,13 @@
     "@aragon/ui": "1.0.0-alpha.26",
     "@babel/polyfill": "^7.2.5",
     "bignumber.js": "^7.2.1",
+    "date-fns": "2.0.0-alpha.22",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
+    "react-router": "^5.1.2",
     "styled-components": "4.1.3",
-    "web3-utils": "^1.0.0",
-    "date-fns": "2.0.0-alpha.22"
+    "web3-utils": "^1.0.0"
   },
   "devDependencies": {
     "@aragon/apps-shared-minime": "1.0.1",
@@ -67,6 +68,7 @@
     "eth-gas-reporter": "0.1.12",
     "ethereumjs-abi": "0.6.5",
     "ganache-cli": "6.1.8",
+    "history": "^4.10.1",
     "homedir": "^0.6.0",
     "lint-staged": "^9.2.0",
     "parcel-bundler": "1.12.3",

--- a/apps/allocations/package.json
+++ b/apps/allocations/package.json
@@ -42,6 +42,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-router": "^5.1.2",
+    "react-router-dom": "^5.1.2",
     "styled-components": "4.1.3",
     "web3-utils": "^1.0.0"
   },

--- a/apps/discussions/package.json
+++ b/apps/discussions/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "dependencies": {
     "@aragon/api": "2.0.0-beta.8",
-    "@aragon/api-react": "2.0.0-beta.6",
+    "@aragon/api-react": "2.0.0-beta.8",
     "@aragon/ui": "1.0.0-alpha.11",
     "@babel/polyfill": "^7.2.5",
     "prop-types": "^15.7.2",

--- a/apps/dot-voting/package.json
+++ b/apps/dot-voting/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@aragon/api": "2.0.0-beta.8",
-    "@aragon/api-react": "2.0.0-beta.6",
+    "@aragon/api-react": "2.0.0-beta.8",
     "@aragon/apps-shared-minime": "1.0.1",
     "@aragon/os": "4.2.0",
     "@aragon/ui": "1.0.0-alpha.32",

--- a/apps/dot-voting/package.json
+++ b/apps/dot-voting/package.json
@@ -37,13 +37,14 @@
     "@aragon/ui": "1.0.0-alpha.32",
     "@babel/polyfill": "^7.2.5",
     "bignumber.js": "^7.2.1",
+    "date-fns": "2.0.0-alpha.22",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-motion": "0.5.2",
+    "react-router": "^5.1.2",
     "styled-components": "4.1.3",
-    "web3-utils": "^1.0.0",
-    "date-fns": "2.0.0-alpha.22"
+    "web3-utils": "^1.0.0"
   },
   "devDependencies": {
     "@aragon/test-helpers": "^1.0.1",
@@ -68,6 +69,7 @@
     "eth-gas-reporter": "0.1.12",
     "ethereumjs-abi": "0.6.5",
     "ganache-cli": "6.1.8",
+    "history": "^4.10.1",
     "homedir": "^0.6.0",
     "lint-staged": "^9.2.0",
     "parcel-bundler": "1.12.3",

--- a/apps/dot-voting/package.json
+++ b/apps/dot-voting/package.json
@@ -43,6 +43,7 @@
     "react-dom": "^16.8.6",
     "react-motion": "0.5.2",
     "react-router": "^5.1.2",
+    "react-router-dom": "^5.1.2",
     "styled-components": "4.1.3",
     "web3-utils": "^1.0.0"
   },

--- a/apps/projects/package.json
+++ b/apps/projects/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@apollo/react-hooks": "^3.1.3",
     "@aragon/api": "2.0.0-beta.8",
-    "@aragon/api-react": "2.0.0-beta.6",
+    "@aragon/api-react": "2.0.0-beta.8",
     "@aragon/apps-shared-minime": "1.0.1",
     "@aragon/apps-vault": "4.1.0",
     "@aragon/os": "4.2.0",

--- a/apps/projects/package.json
+++ b/apps/projects/package.json
@@ -54,6 +54,7 @@
     "react-dom": "^16.8.6",
     "react-markdown": "^4.1.0",
     "react-number-format": "^4.0.8",
+    "react-router": "^5.1.2",
     "styled-components": "4.1.3",
     "web3-utils": "^1.0.0"
   },
@@ -81,6 +82,7 @@
     "eth-gas-reporter": "0.1.12",
     "ethereumjs-abi": "0.6.5",
     "ganache-cli": "6.1.8",
+    "history": "^4.10.1",
     "homedir": "^0.6.0",
     "lint-staged": "^9.2.0",
     "parcel-bundler": "1.12.3",

--- a/apps/projects/package.json
+++ b/apps/projects/package.json
@@ -55,6 +55,7 @@
     "react-markdown": "^4.1.0",
     "react-number-format": "^4.0.8",
     "react-router": "^5.1.2",
+    "react-router-dom": "^5.1.2",
     "styled-components": "4.1.3",
     "web3-utils": "^1.0.0"
   },

--- a/apps/rewards/package.json
+++ b/apps/rewards/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@aragon/api": "2.0.0-beta.8",
-    "@aragon/api-react": "2.0.0-beta.6",
+    "@aragon/api-react": "2.0.0-beta.8",
     "@aragon/apps-shared-minime": "1.0.1",
     "@aragon/apps-vault": "4.1.0",
     "@aragon/os": "4.2.0",

--- a/apps/rewards/package.json
+++ b/apps/rewards/package.json
@@ -43,6 +43,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
+    "react-router": "^5.1.2",
     "styled-components": "4.1.3",
     "web3-utils": "^1.0.0"
   },
@@ -69,6 +70,7 @@
     "eth-gas-reporter": "0.1.12",
     "ethereumjs-abi": "0.6.5",
     "ganache-cli": "6.1.8",
+    "history": "^4.10.1",
     "homedir": "^0.6.0",
     "lint-staged": "^9.2.0",
     "parcel-bundler": "1.12.3",

--- a/apps/rewards/package.json
+++ b/apps/rewards/package.json
@@ -44,6 +44,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-router": "^5.1.2",
+    "react-router-dom": "^5.1.2",
     "styled-components": "4.1.3",
     "web3-utils": "^1.0.0"
   },

--- a/shared/api-react/createAragonHistory.js
+++ b/shared/api-react/createAragonHistory.js
@@ -1,0 +1,104 @@
+// from https://github.com/ReactTraining/history/blob/3f69f9e07b0a739419704cffc3b3563133281548/modules/PathUtils.js#L48
+function createPath(location) {
+  const { pathname, search, hash } = location
+
+  let path = pathname || '/'
+
+  if (search && search !== '?')
+    path += search.charAt(0) === '?' ? search : `?${search}`
+
+  if (hash && hash !== '#') path += hash.charAt(0) === '#' ? hash : `#${hash}`
+
+  return path
+}
+
+// from https://github.com/ReactTraining/history/blob/3f69f9e07b0a739419704cffc3b3563133281548/modules/PathUtils.js#L24
+function parsePath(path) {
+  let pathname = path || '/'
+  let search = ''
+  let hash = ''
+
+  const hashIndex = pathname.indexOf('#')
+  if (hashIndex !== -1) {
+    hash = pathname.substr(hashIndex)
+    pathname = pathname.substr(0, hashIndex)
+  }
+
+  const searchIndex = pathname.indexOf('?')
+  if (searchIndex !== -1) {
+    search = pathname.substr(searchIndex)
+    pathname = pathname.substr(0, searchIndex)
+  }
+
+  return {
+    pathname,
+    search: search === '?' ? '' : search,
+    hash: hash === '#' ? '' : hash
+  }
+}
+
+class AragonHistory {
+  constructor(path, requestPath) {
+    this.path = path
+    this.requestPath = requestPath
+    this.location = {
+      ...parsePath(path),
+
+      // do we want to support these?
+      // key: 'randomString',
+      // state: undefined,
+    }
+    this.createHref = this.createHref.bind(this)
+    this.listeners = []
+    this.appendListener = this.appendListener.bind(this)
+    this.listen = this.listen.bind(this)
+    this.notifyListeners = this.notifyListeners.bind(this)
+    this.go = this.go.bind(this)
+    this.push = this.push.bind(this)
+    this.replace = this.replace.bind(this)
+    this.setRequestPath = this.setRequestPath.bind(this)
+  }
+  appendListener(fn) {
+    function listener(...args) {
+      fn(...args)
+    }
+    this.listeners.push(listener)
+    return () => {
+      this.listeners = this.listeners.filter(item => item !== listener)
+    }
+  }
+  createHref(val) {
+    return createPath(val)
+  }
+  listen(fn) {
+    return this.appendListener(fn)
+  }
+  notifyListeners(...args) {
+    this.listeners.forEach(listener => listener(...args))
+  }
+  go(val) {
+    if (typeof val === 'object') {
+      this.requestPath && this.requestPath(val.pathname + val.search + val.hash)
+      this.location = val
+    } else {
+      this.requestPath && this.requestPath(val)
+      this.location = parsePath(val)
+    }
+    const action = {} // need to pass action to notifyListeners for it to behave properly; not sure if it needs to have a real value
+    this.notifyListeners(this.location, action)
+  }
+  push(val) {
+    this.go(val)
+  }
+  // requestPath does not support replace
+  replace(val) {
+    this.go(val)
+  }
+  setRequestPath(newRequestPath) {
+    this.requestPath = newRequestPath
+  }
+}
+
+export default ({ path, requestPath }) => {
+  return new AragonHistory(path, requestPath)
+}

--- a/shared/api-react/index.js
+++ b/shared/api-react/index.js
@@ -3,12 +3,105 @@ import { Router } from 'react-router'
 import PropTypes from 'prop-types'
 import {
   AragonApi,
+  usePath,
   useAragonApi as useProductionApi,
   useNetwork as useProductionNetwork,
 } from '@aragon/api-react'
 
-// TODO: implement createAragonHistory using usePath hook
-import { createHashHistory as createProductionHistory } from 'history'
+const usePrevious = val => {
+  const ref = React.useRef()
+  React.useEffect(() => {
+    ref.current = val
+  })
+  return ref.current
+}
+
+// from https://github.com/ReactTraining/history/blob/master/modules/PathUtils.js
+function parsePath(path) {
+  let pathname = path || '/'
+  let search = ''
+  let hash = ''
+
+  const hashIndex = pathname.indexOf('#')
+  if (hashIndex !== -1) {
+    hash = pathname.substr(hashIndex)
+    pathname = pathname.substr(0, hashIndex)
+  }
+
+  const searchIndex = pathname.indexOf('?')
+  if (searchIndex !== -1) {
+    search = pathname.substr(searchIndex)
+    pathname = pathname.substr(0, searchIndex)
+  }
+
+  return {
+    pathname,
+    search: search === '?' ? '' : search,
+    hash: hash === '#' ? '' : hash
+  }
+}
+
+class AragonHistory {
+  constructor(path, requestPath) {
+    this.path = path
+    this.requestPath = requestPath
+    this.location = {
+      ...parsePath(path),
+
+      // do we want to support these?
+      // key: 'randomString',
+      // state: undefined,
+    }
+    this.listeners = []
+    this.appendListener = this.appendListener.bind(this)
+    this.listen = this.listen.bind(this)
+    this.notifyListeners = this.notifyListeners.bind(this)
+    this.go = this.go.bind(this)
+    this.push = this.push.bind(this)
+    this.replace = this.replace.bind(this)
+    this.setRequestPath = this.setRequestPath.bind(this)
+  }
+  appendListener(fn) {
+    function listener(...args) {
+      fn(...args)
+    }
+    this.listeners.push(listener)
+    return () => {
+      this.listeners = this.listeners.filter(item => item !== listener)
+    }
+  }
+  listen(fn) {
+    return this.appendListener(fn)
+  }
+  notifyListeners(...args) {
+    this.listeners.forEach(listener => listener(...args))
+  }
+  go(val) {
+    if (typeof val === 'object') {
+      this.requestPath && this.requestPath(val.pathname + val.search + val.hash)
+      this.location = val
+    } else {
+      this.requestPath && this.requestPath(val)
+      this.location = parsePath(val)
+    }
+    const action = {} // need to pass action to notifyListeners for it to behave properly; not sure if it needs to have a real value
+    this.notifyListeners(this.location, action)
+  }
+  push(val) {
+    this.go(val)
+  }
+  // requestPath does not support replace
+  replace(val) {
+    this.go(val)
+  }
+  setRequestPath(newRequestPath) {
+    this.requestPath = newRequestPath
+  }
+}
+
+const createProductionHistory = ({ path, requestPath }) => {
+  return new AragonHistory(path, requestPath)
+}
 
 export default ({ initialState = {}, functions = (() => {}) }) => {
   let useAragonApi = useProductionApi
@@ -27,12 +120,26 @@ export default ({ initialState = {}, functions = (() => {}) }) => {
     if (!inIframe()) {
       useAragonApi = require('./useStubbedApi')({ initialState, functions })
       useNetwork = require('./useStubbedNetwork')
-      // createHistory = require('history').createHashHistory
+      createHistory = require('history').createBrowserHistory
     }
   }
 
   const AragonRouter = props => {
-    const history = React.useRef(createHistory(props))
+    const [ path, requestPath ] = usePath()
+
+    const history = React.useRef(createHistory({ ...props, path, requestPath }))
+
+    const oldPath = usePrevious(path)
+    if (oldPath && oldPath !== path) {
+      history.current.push(path)
+    }
+
+    const oldRequestPath = usePrevious(requestPath)
+    React.useEffect(() => {
+      if (!oldRequestPath && requestPath && history.current.setRequestPath) {
+        history.current.setRequestPath(requestPath)
+      }
+    }, [requestPath])
 
     return (
       <Router history={history.current}>

--- a/shared/api-react/index.js
+++ b/shared/api-react/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Router } from 'react-router'
+import { Router } from 'react-router-dom'
 import PropTypes from 'prop-types'
 import {
   AragonApi,
@@ -7,6 +7,7 @@ import {
   useAragonApi as useProductionApi,
   useNetwork as useProductionNetwork,
 } from '@aragon/api-react'
+import createProductionHistory from './createAragonHistory'
 
 const usePrevious = val => {
   const ref = React.useRef()
@@ -14,93 +15,6 @@ const usePrevious = val => {
     ref.current = val
   })
   return ref.current
-}
-
-// from https://github.com/ReactTraining/history/blob/master/modules/PathUtils.js
-function parsePath(path) {
-  let pathname = path || '/'
-  let search = ''
-  let hash = ''
-
-  const hashIndex = pathname.indexOf('#')
-  if (hashIndex !== -1) {
-    hash = pathname.substr(hashIndex)
-    pathname = pathname.substr(0, hashIndex)
-  }
-
-  const searchIndex = pathname.indexOf('?')
-  if (searchIndex !== -1) {
-    search = pathname.substr(searchIndex)
-    pathname = pathname.substr(0, searchIndex)
-  }
-
-  return {
-    pathname,
-    search: search === '?' ? '' : search,
-    hash: hash === '#' ? '' : hash
-  }
-}
-
-class AragonHistory {
-  constructor(path, requestPath) {
-    this.path = path
-    this.requestPath = requestPath
-    this.location = {
-      ...parsePath(path),
-
-      // do we want to support these?
-      // key: 'randomString',
-      // state: undefined,
-    }
-    this.listeners = []
-    this.appendListener = this.appendListener.bind(this)
-    this.listen = this.listen.bind(this)
-    this.notifyListeners = this.notifyListeners.bind(this)
-    this.go = this.go.bind(this)
-    this.push = this.push.bind(this)
-    this.replace = this.replace.bind(this)
-    this.setRequestPath = this.setRequestPath.bind(this)
-  }
-  appendListener(fn) {
-    function listener(...args) {
-      fn(...args)
-    }
-    this.listeners.push(listener)
-    return () => {
-      this.listeners = this.listeners.filter(item => item !== listener)
-    }
-  }
-  listen(fn) {
-    return this.appendListener(fn)
-  }
-  notifyListeners(...args) {
-    this.listeners.forEach(listener => listener(...args))
-  }
-  go(val) {
-    if (typeof val === 'object') {
-      this.requestPath && this.requestPath(val.pathname + val.search + val.hash)
-      this.location = val
-    } else {
-      this.requestPath && this.requestPath(val)
-      this.location = parsePath(val)
-    }
-    const action = {} // need to pass action to notifyListeners for it to behave properly; not sure if it needs to have a real value
-    this.notifyListeners(this.location, action)
-  }
-  push(val) {
-    this.go(val)
-  }
-  // requestPath does not support replace
-  replace(val) {
-    this.go(val)
-  }
-  setRequestPath(newRequestPath) {
-    this.requestPath = newRequestPath
-  }
-}
-
-const createProductionHistory = ({ path, requestPath }) => {
-  return new AragonHistory(path, requestPath)
 }
 
 export default ({ initialState = {}, functions = (() => {}) }) => {


### PR DESCRIPTION
The magic of ReactRouter is mostly powered by the `history` module. To make our own AragonRouter, I implemented a minimal version of `AragonHistory`. Then, in the AragonRouter component, I listen for updates to `path` and pass them along to `AragonHistory`.

I've demonstrated how this can be used by implementing some basic routing in Allocations. Note that the allocations app itself never needs to bother with `usePath`.