### PR TITLE
Rewards: changed "next payout" to always be in the future

### DIFF
--- a/apps/rewards/app/components/Content/Overview.js
+++ b/apps/rewards/app/components/Content/Overview.js
@@ -8,6 +8,7 @@ import {
   IconView,
   Text,
 } from '@aragon/ui'
+import { isAfter } from 'date-fns'
 import {
   ONE_TIME_DIVIDEND,
   RECURRING_DIVIDEND,
@@ -86,7 +87,8 @@ const renderOneTimeDividend = (reward) => {
     dateReference,
     endBlock,
   } = reward
-  const nextPayout = dateReference.toDateString() + ` (block: ${endBlock})`
+  const nextPayout = isAfter(dateReference, new Date())
+    ? dateReference.toDateString() + ` (block: ${endBlock})` : 'Completed'
   const displayAmount = `${displayCurrency(amount)} ${amountToken}`
   return [ description, DIVIDEND, ONE_TIME, nextPayout, displayAmount ]
 }
@@ -104,9 +106,9 @@ const renderRecurringDividend = (reward) => {
   const frequency = `${RECURRING} (${disbursement} ${disbursementUnit})`
   const today = new Date()
   const date = disbursements.find(d => d.getTime() > today.getTime())
-    || disbursements[disbursements.length - 1]
   const block = disbursementBlocks[disbursements.indexOf(date)]
-  const nextPayout = `${date.toDateString()} (block: ${block})`
+  const nextPayout = date === undefined
+    ? 'Completed' : `${date.toDateString()} (block: ${block})`
   const displayAmount = `${displayCurrency(amount)} ${amountToken}`
   return [ description, DIVIDEND, frequency, nextPayout, displayAmount ]
 }
@@ -120,7 +122,8 @@ const renderOneTimeMerit = (reward) => {
     endDate,
     endBlock,
   } = reward
-  const nextPayout = new Date(endDate).toDateString() + ` (block: ${endBlock})`
+  const nextPayout = isAfter(endDate, new Date())
+    ? new Date(endDate).toDateString() + ` (block: ${endBlock})` : 'Completed'
   const displayAmount = `${displayCurrency(amount)} ${amountToken}`
   return [ description, MERIT, ONE_TIME, nextPayout, displayAmount ]
 }


### PR DESCRIPTION
Fixes #1614

If there are no future payouts, "Completed" is shown instead.

![Screenshot from 2019-12-09 16-33-37](https://user-images.githubusercontent.com/16065447/70475053-ba8bc380-1aa1-11ea-86f7-8500ae5eb7d9.png)
