### PR TITLE
Both Review panels can be now read-only

### DIFF
--- a/apps/projects/app/components/Content/IssueDetail/BountyCard.js
+++ b/apps/projects/app/components/Content/IssueDetail/BountyCard.js
@@ -89,14 +89,14 @@ const Submissions = ({ issue }) => {
     'No applications'
   )
   case 'review-applicants': return (
-    <Link onClick={() => reviewApplication(issue, 0)}>
+    <Link onClick={() => reviewApplication({ issue, requestIndex: 0 })}>
       {pluralize('application', issue.requestsData.length)}
 
     </Link>
   )
   case 'in-progress':
     if ('workSubmissions' in issue) return (
-      <Link onClick={() => reviewWork(issue, 0)}>
+      <Link onClick={() => reviewWork({ issue, index: 0 })}>
         {pluralize('work submission', issue.workSubmissions.length)}
       </Link>
     )
@@ -105,7 +105,7 @@ const Submissions = ({ issue }) => {
     )
   case 'review-work':
   case 'fulfilled': return (
-    <Link onClick={() => reviewWork(issue, 0)}>
+    <Link onClick={() => reviewWork({ issue, index: 0 })}>
       {pluralize('work submission', issue.workSubmissions.length)}
     </Link>)
   default: return null

--- a/apps/projects/app/components/Content/IssueDetail/EventsCard.js
+++ b/apps/projects/app/components/Content/IssueDetail/EventsCard.js
@@ -53,13 +53,13 @@ IssueEvent.propTypes = {
 
 const applicationLink = (user, onReviewApplication, issue, index) => (
   <React.Fragment>
-    {user} submitted <Link onClick={() => onReviewApplication(issue, index)}>an application for review</Link>
+    {user} submitted <Link onClick={() => onReviewApplication(issue, index, true)}>an application for review</Link>
   </React.Fragment>
 )
 
 const workLink = (user, onReviewWork, issue, index) => (
   <React.Fragment>
-    {user} submitted <Link onClick={() => onReviewWork(issue, index)}>work for review</Link>
+    {user} submitted <Link onClick={() => onReviewWork(issue, index, true)}>work for review</Link>
   </React.Fragment>
 )
 

--- a/apps/projects/app/components/Content/IssueDetail/EventsCard.js
+++ b/apps/projects/app/components/Content/IssueDetail/EventsCard.js
@@ -53,13 +53,17 @@ IssueEvent.propTypes = {
 
 const applicationLink = (user, onReviewApplication, issue, index) => (
   <React.Fragment>
-    {user} submitted <Link onClick={() => onReviewApplication(issue, index, true)}>an application for review</Link>
+    {user} submitted <Link onClick={() =>
+      onReviewApplication({ issue, index, readOnly: true })
+    }>an application for review</Link>
   </React.Fragment>
 )
 
 const workLink = (user, onReviewWork, issue, index) => (
   <React.Fragment>
-    {user} submitted <Link onClick={() => onReviewWork(issue, index, true)}>work for review</Link>
+    {user} submitted <Link onClick={() =>
+      onReviewWork({ issue, index, readOnly: true })
+    }>work for review</Link>
   </React.Fragment>
 )
 

--- a/apps/projects/app/components/Panel/ReviewApplication/ReviewApplication.js
+++ b/apps/projects/app/components/Panel/ReviewApplication/ReviewApplication.js
@@ -22,7 +22,7 @@ import { toHex } from 'web3-utils'
 import { issueShape } from '../../../utils/shapes.js'
 import { IssueTitle } from '../PanelComponents'
 
-const ReviewApplication = ({ issue, requestIndex }) => {
+const ReviewApplication = ({ issue, requestIndex, readOnly }) => {
   const githubCurrentUser = useGithubAuth()
   const {
     api: { reviewApplication },
@@ -130,7 +130,7 @@ const ReviewApplication = ({ issue, requestIndex }) => {
         </Estimations>
       </ApplicationDetails>
 
-      {('review' in request) ? (
+      {('review' in request) && (
         <React.Fragment>
 
           <FieldTitle>Application Status</FieldTitle>
@@ -158,7 +158,8 @@ const ReviewApplication = ({ issue, requestIndex }) => {
             {request.review.feedback.length ? request.review.feedback : 'No feedback was provided'}
           </Text.Block>
         </React.Fragment>
-      ) : (
+      )}
+      {!(readOnly || 'review' in request) && (
         <React.Fragment>
           <FormField
             label="Feedback"
@@ -196,6 +197,7 @@ const ReviewApplication = ({ issue, requestIndex }) => {
 ReviewApplication.propTypes = {
   issue: issueShape,
   requestIndex: PropTypes.number.isRequired,
+  readOnly: PropTypes.bool.isRequired,
 }
 
 const UserLink = styled.div`

--- a/apps/projects/app/components/Panel/ReviewApplication/ReviewApplication.js
+++ b/apps/projects/app/components/Panel/ReviewApplication/ReviewApplication.js
@@ -159,7 +159,7 @@ const ReviewApplication = ({ issue, requestIndex, readOnly }) => {
           </Text.Block>
         </React.Fragment>
       )}
-      {!(readOnly || 'review' in request) && (
+      {!readOnly && !request.review && (
         <React.Fragment>
           <FormField
             label="Feedback"

--- a/apps/projects/app/components/Panel/ReviewWork/ReviewWork.js
+++ b/apps/projects/app/components/Panel/ReviewWork/ReviewWork.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { format as formatDate, formatDistance } from 'date-fns'
 import { BN } from 'web3-utils'
@@ -25,7 +26,7 @@ import { issueShape } from '../../../utils/shapes.js'
 import { IssueTitle } from '../PanelComponents'
 import workRatings from '../../../utils/work-ratings.js'
 
-const ReviewWork = ({ issue }) => {
+const ReviewWork = ({ issue, readOnly }) => {
   const githubCurrentUser = useGithubAuth()
   const {
     api: { reviewSubmission },
@@ -119,7 +120,7 @@ const ReviewWork = ({ issue }) => {
         <DetailText>{work.hours}</DetailText>
       </SubmissionDetails>
 
-      {('review' in work) ? (
+      {('review' in work) && (
         <React.Fragment>
           <FieldTitle>Submission Status</FieldTitle>
           <FieldText>
@@ -155,7 +156,8 @@ const ReviewWork = ({ issue }) => {
             </Text.Block>
           </FieldText>
         </React.Fragment>
-      ) : (
+      )}
+      {!(readOnly || 'review' in work) && (
         <React.Fragment>
 
           <FormField
@@ -210,7 +212,10 @@ const ReviewWork = ({ issue }) => {
   )
 }
 
-ReviewWork.propTypes = issueShape
+ReviewWork.propTypes = {
+  issue: issueShape,
+  readOnly: PropTypes.bool.isRequired,
+}
 
 const SubmissionDetails = styled.div`
   border: 1px solid ${p => p.border};

--- a/apps/projects/app/components/Panel/ReviewWork/ReviewWork.js
+++ b/apps/projects/app/components/Panel/ReviewWork/ReviewWork.js
@@ -157,7 +157,7 @@ const ReviewWork = ({ issue, readOnly }) => {
           </FieldText>
         </React.Fragment>
       )}
-      {!(readOnly || 'review' in work) && (
+      {!readOnly && !work.review && (
         <React.Fragment>
 
           <FormField

--- a/apps/projects/app/components/Panel/usePanelManagement.js
+++ b/apps/projects/app/components/Panel/usePanelManagement.js
@@ -37,7 +37,7 @@ const usePanelManagement = () => {
         issue
       })
     },
-    reviewApplication: (issue, requestIndex = 0, readOnly = false) => {
+    reviewApplication: ({ issue, requestIndex = 0, readOnly = false }) => {
       setActivePanel(PANELS.ReviewApplication)
       setPanelProps({
         issue,
@@ -46,7 +46,7 @@ const usePanelManagement = () => {
         title: 'View application',
       })
     },
-    reviewWork: (issue, index = 0, readOnly = false) => {
+    reviewWork: ({ issue, index = 0, readOnly = false }) => {
       setActivePanel(PANELS.ReviewWork)
       setPanelProps({
         issue,

--- a/apps/projects/app/components/Panel/usePanelManagement.js
+++ b/apps/projects/app/components/Panel/usePanelManagement.js
@@ -37,19 +37,21 @@ const usePanelManagement = () => {
         issue
       })
     },
-    reviewApplication: (issue, requestIndex = 0) => {
+    reviewApplication: (issue, requestIndex = 0, readOnly = false) => {
       setActivePanel(PANELS.ReviewApplication)
       setPanelProps({
         issue,
         requestIndex,
-        title: 'View application'
+        readOnly,
+        title: 'View application',
       })
     },
-    reviewWork: (issue, index = 0) => {
+    reviewWork: (issue, index = 0, readOnly = false) => {
       setActivePanel(PANELS.ReviewWork)
       setPanelProps({
         issue,
         index,
+        readOnly,
         title: 'View work'
       })
     },

--- a/apps/projects/app/components/Shared/BountyContextMenu.js
+++ b/apps/projects/app/components/Shared/BountyContextMenu.js
@@ -39,7 +39,7 @@ const BountyContextMenu = ({ issue }) => {
               </ActionLabel>
             </Item>
           )}
-          <Item onClick={() => reviewApplication(issue)}>
+          <Item onClick={() => reviewApplication({ issue })}>
             <IconView color={`${theme.surfaceContent}`} />
             <ActionLabel>
               View applications ({issue.requestsData.length})
@@ -50,13 +50,13 @@ const BountyContextMenu = ({ issue }) => {
       )}
       {workStatus === 'review-work' && (
         <React.Fragment>
-          <Item onClick={() => reviewWork(issue)}>
+          <Item onClick={() => reviewWork({ issue })}>
             <IconView color={`${theme.surfaceContent}`} />
             <ActionLabel>
               View work
             </ActionLabel>
           </Item>
-          <Item onClick={() => reviewApplication(issue)}>
+          <Item onClick={() => reviewApplication({ issue })}>
             <IconView color={`${theme.surfaceIcon}`} />
             <ActionLabel>
               View applications ({issue.requestsData.length})
@@ -88,7 +88,7 @@ const BountyContextMenu = ({ issue }) => {
               </ActionLabel>
             </Item>
           )}
-          <Item onClick={() => reviewApplication(issue)}>
+          <Item onClick={() => reviewApplication({ issue })}>
             <IconView color={`${theme.surfaceContent}`} />
             <ActionLabel>
               View applications ({issue.requestsData.length})
@@ -105,13 +105,13 @@ const BountyContextMenu = ({ issue }) => {
       )}
       {workStatus === 'fulfilled' && (
         <React.Fragment>
-          <Item onClick={() => reviewWork(issue)}>
+          <Item onClick={() => reviewWork({ issue })}>
             <IconView color={`${theme.surfaceIcon}`} />
             <ActionLabel>
               View work
             </ActionLabel>
           </Item>
-          <Item onClick={() => reviewApplication(issue)}>
+          <Item onClick={() => reviewApplication({ issue })}>
             <IconView color={`${theme.surfaceIcon}`} />
             <ActionLabel>
               View applications ({issue.requestsData.length})


### PR DESCRIPTION
A bool variable has been introduced, so links in Activity log
can modify default behavior - which is to show review form
in those panels (unless review had already taken place).

No cleanup was intended here - there is another PR dealing
with Status and Avatar components. This PR is to strictly
add RO mode to the panels.

Screen (work submission, application submission looks pretty much the same):
![Screenshot from 2019-12-10 16-25-04](https://user-images.githubusercontent.com/34452131/70542830-b75c0a80-1b69-11ea-8fba-e97447506bd8.png)
