### PR TITLE
bug fix: setValidate is called onFocus, not onBlur

### DIFF
--- a/apps/projects/app/components/Panel/FundIssues/FundIssues.js
+++ b/apps/projects/app/components/Panel/FundIssues/FundIssues.js
@@ -347,7 +347,7 @@ const FundForm = ({
                     issue={issue}
                     bounty={bounties[issue.id]}
                     tokens={tokens}
-                    onBlur={() => setValidate(true)}
+                    onFocus={() => setValidate(true)}
                     updateBounty={updateBounty(issue.id)}
                   />
                 ))}


### PR DESCRIPTION
Short story: onBlur handler never fires, so setValidate is never set to true, so Submit button is never enabled, as per the screen below. Replacing it with onFocus (as it was before) seems to fix it. I've no information why it got replaced in the first place, so... at least now the form is usable.

![Screenshot from 2019-12-16 10-45-01](https://user-images.githubusercontent.com/34452131/70896551-3087b180-1ff1-11ea-9ee4-be0e80a0b9cb.png)
