### PR TITLE
Bounty work status

### DIFF
--- a/apps/projects/app/components/Content/IssueDetail/BountyCard.js
+++ b/apps/projects/app/components/Content/IssueDetail/BountyCard.js
@@ -40,7 +40,7 @@ const fulfillerAddress = issue => {
   if (!issue.openSubmission) return address(issue.assignee)
 
   const approvedWork = issue.workSubmissions.find(submission =>
-    'review' in submission && submission.review.accepted
+    'review' in submission && submission.review.approved
   )
   return address(approvedWork.submitter)
 }

--- a/apps/projects/app/components/Content/IssueDetail/EventsCard.js
+++ b/apps/projects/app/components/Content/IssueDetail/EventsCard.js
@@ -120,7 +120,7 @@ const activities = (
           date: data.review.reviewDate,
           user: data.user,
           eventDescription: (
-            data.user.login + (data.review.accepted ?
+            data.user.login + (data.review.approved ?
               '\'s work was accepted'
               :
               '\'s work was rejected'

--- a/apps/projects/app/store/helpers/issues.js
+++ b/apps/projects/app/store/helpers/issues.js
@@ -117,7 +117,7 @@ const isWorkDone = issue => {
 
   return issue.workSubmissions.some(work =>
     work.hasOwnProperty('review') &&
-      work.review.accepted
+      work.review.approved
   )
 }
 


### PR DESCRIPTION
Creating standard Status component:
![Screenshot from 2019-12-16 11-57-30](https://user-images.githubusercontent.com/34452131/70901564-51550480-1ffb-11ea-8e10-41fa6b1a97ca.png)

 (for Application and Work) Review Panels changed work submission to be `approved` rather than `accepted` (because applications are `approved`). The change wasn't thorough enough though, resulting in work status to not be recognized after accepting. This PR fixes it. It's purely internal change, it's not reflected on UI.
