### PR TITLE
Incorrect status field in Application request

### DIFF
--- a/apps/projects/app/store/helpers/issues.js
+++ b/apps/projects/app/store/helpers/issues.js
@@ -3,8 +3,6 @@ import { app } from '../app'
 import { ipfsGet } from '../../utils/ipfs-helpers'
 import standardBounties from '../../abi/StandardBounties.json'
 
-const assignmentRequestStatus = [ 'Unreviewed', 'Accepted', 'Rejected' ]
-
 export const loadIssueData = async ({ repoId, issueNumber }) => {
   const {
     hasBounty,
@@ -146,7 +144,6 @@ const getRequest = (repoId, issueNumber, applicantId) => {
       const bountyData = await ipfsGet(response.application)
       resolve({
         contributorAddr: response.applicant,
-        status: assignmentRequestStatus[parseInt(response.status)],
         requestIPFSHash: response.application,
         ...bountyData
       })
@@ -185,7 +182,6 @@ export const buildSubmission = async ({ fulfillmentId, fulfillers, ipfsHash, sub
     fulfillers,
     hours,
     proof,
-    status: '0',
     submissionDate,
     submissionIPFSHash: ipfsHash,
     submitter,


### PR DESCRIPTION
Each Application (request for work on a given issue) had a `status`
field containing text version of the application status: Unreviewed,
Accepted, Rejected. However, because the application was saved
on IPFS in its entirety, including initial Unreviewed status,
it was ignoring further (post-request-review) status changes.

It was not a problem, because we never relied on the status being
correct. We use `review.approved` as the ultimately (and correct)
source of truth.

The choice was between fixing the status field and removing it.
The reasons for choosing to remove it instead of fixing are:
1. There is no analogous field in Work Submission,
2. It's more complicated to fix it - correct way of fixing it
   would require not storing it on IPFS == actively removing
   it from data we need to store on IPFS,
3. It's not in use anyway. We have another and equally correct
   way of determining the application status, and it is the same
   way we use for Work Submissions. Standards FTW.