### PR TITLE
bug fix: Status component used in Review panels updated

### DIFF
--- a/apps/projects/app/components/Panel/PanelComponents.js
+++ b/apps/projects/app/components/Panel/PanelComponents.js
@@ -71,9 +71,9 @@ const statuses = [
   { color: 'positive', text: 'Accepted' },
 ]
 
-export const Status = ({ review }) => {
+export const Status = ({ reviewDate, approved }) => {
   const theme = useTheme()
-  const status = statuses[Number(review.approved)]
+  const status = statuses[Number(approved)]
   const text = status.text
   const color = theme[status.color]
   return (
@@ -81,16 +81,14 @@ export const Status = ({ review }) => {
       <IconCheck color={color} css={`margin-top: -${0.5 * GU}px; margin-right: ${GU}px`} />
       <Text color={`${color}`}>{text}</Text>
       <Text color={`${theme.contentSecondary}`} css={`margin-left: ${GU}px`}>
-        {formatDate(new Date(review.reviewDate), 'd MMM yy, h:MM a (z)')}
+        {formatDate(new Date(reviewDate), 'd MMM yy, h:MM a (z)')}
       </Text>
     </div>
   )
 }
 Status.propTypes = {
-  review: PropTypes.shape({
-    approved: PropTypes.bool.isRequired,
-    reviewDate: PropTypes.string.isRequired,
-  }).isRequired,
+  reviewDate: PropTypes.string.isRequired,
+  approved: PropTypes.bool.isRequired,
 }
 
 export const ReviewButtons = ({ onAccept, onReject, disabled }) => (

--- a/apps/projects/app/components/Panel/PanelComponents.js
+++ b/apps/projects/app/components/Panel/PanelComponents.js
@@ -87,8 +87,8 @@ export const Status = ({ reviewDate, approved }) => {
   )
 }
 Status.propTypes = {
-  reviewDate: PropTypes.string.isRequired,
   approved: PropTypes.bool.isRequired,
+  reviewDate: PropTypes.string.isRequired,
 }
 
 export const ReviewButtons = ({ onAccept, onReject, disabled }) => (

--- a/apps/projects/app/components/Panel/ReviewApplication/ReviewApplication.js
+++ b/apps/projects/app/components/Panel/ReviewApplication/ReviewApplication.js
@@ -83,7 +83,7 @@ const ReviewApplication = ({ issue, requestIndex, readOnly }) => {
     eta: (request.eta === '-') ? request.eta : (new Date(request.eta)).toLocaleDateString(),
     applicationDate: request.applicationDate
   }
-  
+
   const applicant = application.user
   const applicantName = applicant.name ? applicant.name : applicant.login
   const applicationDateDistance = formatDistance(new Date(application.applicationDate), new Date())
@@ -128,7 +128,7 @@ const ReviewApplication = ({ issue, requestIndex, readOnly }) => {
           <FieldTitle>Application Status</FieldTitle>
 
           <FieldText>
-            <Status review={request.review} />
+            <Status reviewDate={request.review.reviewDate} approved={request.review.approved} />
           </FieldText>
 
           <FieldTitle>Feedback</FieldTitle>

--- a/apps/projects/app/components/Panel/ReviewWork/ReviewWork.js
+++ b/apps/projects/app/components/Panel/ReviewWork/ReviewWork.js
@@ -41,12 +41,12 @@ const ReviewWork = ({ issue, readOnly }) => {
   const [ feedback, setFeedback ] = useState('')
   const [ rating, setRating ] = useState(-1)
 
-  const buildReturnData = (approved) => {
+  const buildReturnData = accepted => {
     const today = new Date()
     return {
       feedback,
       rating,
-      approved,
+      accepted,
       user: githubCurrentUser,
       reviewDate: today.toISOString(),
     }
@@ -59,8 +59,8 @@ const ReviewWork = ({ issue, readOnly }) => {
 
   const canSubmit = () => !(rating > 0)
 
-  const onReviewSubmission = async (approved) => {
-    const data = buildReturnData(approved)
+  const onReviewSubmission = async accepted => {
+    const data = buildReturnData(accepted)
 
     // new IPFS data is old data plus state returned from the panel
     const ipfsData = issue.workSubmissions[issue.workSubmissions.length - 1]
@@ -78,7 +78,7 @@ const ReviewWork = ({ issue, readOnly }) => {
       toHex(issue.repoId),
       issue.number,
       issue.workSubmissions.length - 1,
-      approved,
+      accepted,
       requestIPFSHash,
       fulfillmentAmounts
     ).toPromise()
@@ -117,7 +117,7 @@ const ReviewWork = ({ issue, readOnly }) => {
         <React.Fragment>
           <FieldTitle>Submission Status</FieldTitle>
           <FieldText>
-            <Status review={work.review} />
+            <Status reviewDate={work.review.reviewDate} approved={work.review.accepted} />
           </FieldText>
 
           <FieldTitle>Feedback</FieldTitle>


### PR DESCRIPTION
So it can be used in both panels without significant changes.
Status (rejected/approved) is stored in different variables -
WorkSubmissions have variable called 'accepted', the same
variable in Applications is called 'approved'.