### PR TITLE
Allocations: make formatDate support more browsers

### DIFF
--- a/apps/allocations/app/utils/helpers.js
+++ b/apps/allocations/app/utils/helpers.js
@@ -10,7 +10,11 @@ export const sortByDateKey = key => {
 }
 export function formatDate({ date, short }) {
   return new Intl.DateTimeFormat(undefined, {
-    dateStyle: 'long',
-    timeStyle: short ? undefined : 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: short ? undefined : 'numeric',
+    minute: short ? undefined : '2-digit',
+    timeZoneName: short ? undefined : 'short',
   }).format(date)
 }


### PR DESCRIPTION
* old Chrome: `December 17, 2019 at 4:56:42 PM EST`
* old Firefox: `12/17/2019`

New everywhere: `December 17, 2019, 4:57 PM EST`

(short version: `December 17, 2019`)

Note that this respects the browser's locale. If your browser is in Spanish, you will see: `17 de diciembre de 2019 16:59 GMT-5`