### PR TITLE
patch Continuous deploy publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,14 +69,17 @@ jobs:
         -in shared/deployments/rinkeby_key.json.enc -out $HOME/.aragon/rinkeby_key.json -d
       - ls $HOME/.aragon
       install:
-        - travis_wait npm i -g @aragon/cli@6.3.3
+        - travis_wait npm i -g @aragon/cli@5.6.2
         - npm run bootstrap
       script: npm run publish:cd
 
 
 notifications:
   webhooks: https://coveralls.io/webhook
-  email: false
+  email:
+    recipients:
+      - jobs@autark.xyz
+    if: branch = dev
 
 # Only build pushes to dev. All pull requests still build
 branches:

--- a/shared/deployments/check-publish.sh
+++ b/shared/deployments/check-publish.sh
@@ -14,6 +14,7 @@ git diff --quiet HEAD~ HEAD -- $PWD/app $PWD/../../shared/identity $PWD/../../sh
 
 if [ $? == "1" ]
 then
+  npm run compile # remove after CLI is bumped to v6 or higher
   aragon apm publish minor --files dist/ --environment continuous-deployment --apm.ipfs.rpc https://ipfs.autark.xyz:5001 --ipfs-check false --propagate-content false --skip-confirmation
   exit $?
 else


### PR DESCRIPTION
- bump aragonCLI CI dep down to 5.6.2 **Note** This is temporary until the wrapper dependencies are fixed in later releases of the CLI
- add in email notifications