### PR TITLE
fix: corrected Estimated Date in View Application Panel

### DIFF
--- a/apps/projects/app/components/Form/Input/DatePicker.js
+++ b/apps/projects/app/components/Form/Input/DatePicker.js
@@ -24,14 +24,14 @@ const Container = styled.div`
   min-width: 15em;
   margin: 0 auto;
   padding-top: 0.5em;
-  background: ${theme.contentBackground};
+  background: white;
   border: 1px solid ${theme.contentBorder};
   border-radius: 3px;
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.06);
-  
   ${props => props.overlay && css`
     &&& {
       position: absolute;
+      background: white;
       right: 0;
       z-index: 10;
       box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
@@ -76,7 +76,6 @@ const DayView = styled.li`
   cursor: pointer;
   font-size: 90%;
   user-select: none;
-
   ${props => props.today && css`
     border: 1px solid ${theme.disabled};
   `}
@@ -85,7 +84,6 @@ const DayView = styled.li`
     pointer-events: none;
     color: ${theme.disabled};
   `}
-  
   ${props => props.selected && css`
     &&& {
       background: ${mainColor};
@@ -93,8 +91,7 @@ const DayView = styled.li`
       color: ${theme.negativeText};
     }
   `}
-
-  &:after {
+  &::after {
     display: block;
     content: '';
     margin-top: 100%;

--- a/apps/projects/app/components/Panel/FundIssues/FundIssues.js
+++ b/apps/projects/app/components/Panel/FundIssues/FundIssues.js
@@ -487,7 +487,7 @@ const FundIssues = ({ issues, mode }) => {
     ).toPromise()
 
     closePanel()
-  }, [bounties])
+  }, [ bounties, openSubmission ])
 
   if (fundsAvailable.toString() === '0') {
     return (

--- a/apps/projects/app/components/Panel/ReviewApplication/ReviewApplication.js
+++ b/apps/projects/app/components/Panel/ReviewApplication/ReviewApplication.js
@@ -80,7 +80,7 @@ const ReviewApplication = ({ issue, requestIndex, readOnly }) => {
     },
     workplan: request.workplan,
     hours: request.hours,
-    eta: (request.eta === '-') ? request.eta : (new Date(request.eta)).toLocaleDateString(),
+    eta: (request.eta === '-') ? request.eta : formatDate(new Date(request.eta), 'MMM d'),
     applicationDate: request.applicationDate
   }
 
@@ -118,7 +118,7 @@ const ReviewApplication = ({ issue, requestIndex, readOnly }) => {
           </div>
           <div>
             <FieldTitle>Estimated Date</FieldTitle>
-            <Text>{formatDate(new Date(application.eta), 'MMM d')}</Text>
+            <Text>{application.eta}</Text>
           </div>
         </Estimations>
       </SubmissionDetails>


### PR DESCRIPTION
Issue: if not set, Estimated Date shows up as "Invalid Date". it should be either '-' if not set of correct Date in "month day" format. Screen before:

![](https://user-images.githubusercontent.com/28843778/71257234-7915d680-2333-11ea-8e9e-ad6f8f0cfd82.png)

Screen after:

![Screenshot from 2019-12-20 15-36-07](https://user-images.githubusercontent.com/34452131/71261777-85ebf780-233e-11ea-9876-86322be99bc8.png)

