### PR TITLE
fix: use correct key `requestIndex`

### DIFF
--- a/apps/projects/app/components/Content/IssueDetail/EventsCard.js
+++ b/apps/projects/app/components/Content/IssueDetail/EventsCard.js
@@ -50,10 +50,10 @@ IssueEvent.propTypes = {
   date: PropTypes.string.isRequired,
 }
 
-const applicationLink = (user, onReviewApplication, issue, index) => (
+const applicationLink = (user, onReviewApplication, issue, requestIndex) => (
   <React.Fragment>
     {user} submitted <Link onClick={() =>
-      onReviewApplication({ issue, index, readOnly: true })
+      onReviewApplication({ issue, requestIndex, readOnly: true })
     }>an application for review</Link>
   </React.Fragment>
 )


### PR DESCRIPTION
The generic `index` key was getting passed in and was not recognized by
the (re)view application panel. resolves #1810