### PR TITLE
fix: deep-linked issues with bounties crash

### DIFF
--- a/apps/projects/app/App.js
+++ b/apps/projects/app/App.js
@@ -154,12 +154,13 @@ const App = () => {
   tabs.push({ name: 'Settings', body: Settings })
 
   // Determine current tab details
-  const currentTab = tabs.find(t => t.name.toLowerCase() === selectedTab)
-  const TabComponent = currentTab.body
+  const currentTab = tabs.find(t => t.name.toLowerCase() === selectedTab) || {}
+  const { body: tabBody = null, name: tabName = null } = currentTab
+  const TabComponent = tabBody
   const TabAction = () => {
     const { setupNewIssue, setupNewProject } = usePanelManagement()
 
-    switch (currentTab.name) {
+    switch (tabName) {
     case 'Overview': return (
       <Button mode="strong" icon={<IconPlus />} onClick={setupNewProject} label="New project" />
     )

--- a/apps/projects/app/hooks/useShapedIssue.js
+++ b/apps/projects/app/hooks/useShapedIssue.js
@@ -19,7 +19,7 @@ export default () => {
   const shapeIssue = useCallback(issue => {
     const bounty = bounties[issue.number]
     const repoIdFromBounty = bounty && bounty.data.repoId
-    if (bounty && repoIdFromBounty === issue.repository.id) {
+    if ((bounty && tokens[bounty.data.token]) && repoIdFromBounty === issue.repository.id) {
       const data = bounties[issue.number].data
       const balance = BigNumber(bounties[issue.number].data.balance)
         .div(BigNumber(10 ** tokens[data.token].decimals))


### PR DESCRIPTION
If a deep-linked issue has a bounty, the app will crash since tokens
often don't load until after all native app state has loaded. This fixes
it by adding in checks for tokens and also sets some default properties
for Tabs that prevent another crash during deep link resolution

# Before
![before 2019-12-20 17-10](https://user-images.githubusercontent.com/17910833/71298820-804add80-234f-11ea-8cbc-bd9553166448.gif)
# After
![After 2019-12-20 17-10](https://user-images.githubusercontent.com/17910833/71298829-922c8080-234f-11ea-8ce9-ad4336f6d824.gif)
