### PR TITLE
Allocations/Budget Card: wrap title to two lines

### DIFF
--- a/apps/allocations/app/components/Card/Budget.js
+++ b/apps/allocations/app/components/Card/Budget.js
@@ -51,7 +51,10 @@ const Wrapper = ({ budget, children, theme }) => {
   const { requestPath } = usePathHelpers()
   const { active, amount, id, name, token } = budget
   return (
-    <Link onClick={() => requestPath(`/budgets/${id}`)}>
+    <Link
+      css="white-space: normal"
+      onClick={() => requestPath(`/budgets/${id}`)}
+    >
       <StyledCard theme={theme}>
         <CardTop>
           <CardTitle theme={theme}>{name}</CardTitle>


### PR DESCRIPTION
The [addition of the aragonUI Link](https://github.com/AutarkLabs/open-enterprise/pull/1758/files?w=1#diff-e811bc466b88a1c9cdb6ad5273ffc7a7R54) caused all elements within the card to inherit the `white-space: nowrap` rule, breaking the line wrapping

## Before

<img width="278" alt="before" src="https://user-images.githubusercontent.com/221614/71370353-aead0080-257b-11ea-9a33-d95c27ad78aa.png">

## After

<img width="281" alt="after" src="https://user-images.githubusercontent.com/221614/71370352-aead0080-257b-11ea-80be-00dc6df66388.png">

