### PR TITLE
Markdown formatting fixes

### DIFF
--- a/apps/discussions/package.json
+++ b/apps/discussions/package.json
@@ -10,7 +10,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "react-markdown": "^4.1.0",
+    "react-markdown": "^4.2.2",
     "styled-components": "4.1.3",
     "ipfs-http-client": "^32.0.1",
     "lodash.clonedeep": "^4.5.0"

--- a/apps/projects/package.json
+++ b/apps/projects/package.json
@@ -52,7 +52,7 @@
     "react": "^16.8.6",
     "react-apollo": "^2.3.2",
     "react-dom": "^16.8.6",
-    "react-markdown": "^4.1.0",
+    "react-markdown": "^4.2.2",
     "react-number-format": "^4.0.8",
     "styled-components": "4.1.3",
     "web3-utils": "^1.0.0"

--- a/shared/ui/components/misc/Markdown.js
+++ b/shared/ui/components/misc/Markdown.js
@@ -20,8 +20,8 @@ const ListItem = ({ checked, children }) => {
 }
 
 ListItem.propTypes = {
-  checked: PropTypes.bool.isRequired,
-  children: PropTypes.element.isRequired,
+  checked: PropTypes.bool,
+  children: PropTypes.node.isRequired,
 }
 
 const Markdown = ({ content, style }) => {

--- a/shared/ui/components/misc/Markdown.js
+++ b/shared/ui/components/misc/Markdown.js
@@ -103,7 +103,10 @@ const MarkdownWrapper = styled.div`
 
   a {
     color: ${theme.gradientStart};
+    display: inline;
     text-decoration: none;
+    white-space: normal;
+    word-break: break-word;
   }
   a:hover {
     text-decoration: underline;


### PR DESCRIPTION
* Fix propTypes checks
* Fix link styling
* Update dependency

See "before" screenshot in #1822. Here's how it looks now:

<img width="480" alt="Screen Shot 2019-12-23 at 12 57 07" src="https://user-images.githubusercontent.com/221614/71373079-02234c80-2584-11ea-93ad-c9cf63b55da1.png">

---

I also spent some time researching why our solution formats some text blocks differently than GitHub. Example text block:

    **To Reproduce**
    Steps to reproduce the behavior:
    1. Go to 'rewards'
    2. Click on 'New Reward.'
    3. Scroll down to 'Recurring Dividend'
    4. See error once go to the voting and attempt to execute

Here's how GitHub renders this:
 
<img width="300" alt="Screen Shot 2019-12-23 at 12 57 16" src="https://user-images.githubusercontent.com/221614/71373107-1404ef80-2584-11ea-8fe3-4a176f48d793.png">

Here's how react-markdown renders it:

<img width="442" alt="Screen Shot 2019-12-23 at 12 57 28" src="https://user-images.githubusercontent.com/221614/71373120-20894800-2584-11ea-9f9e-82edc74717d1.png">

Note, however, that this is ill-formatted markdown! Well-formatted markdown would put an extra line break below the first and second lines of text, like this:

    **To Reproduce**

    Steps to reproduce the behavior:

    1. Go to 'rewards'
    2. Click on 'New Reward.'
    3. Scroll down to 'Recurring Dividend'
    4. See error once go to the voting and attempt to execute

If formatted like this, our renderer matches GitHub's:

<img width="294" alt="Screen Shot 2019-12-23 at 13 00 19" src="https://user-images.githubusercontent.com/221614/71373158-36970880-2584-11ea-86f0-7dcb85b9f5a7.png">

I tried to find some options to pass to react-markdown to make it render more like GitHub. Surprisingly, "GitHub-Flavored Markdown" is the default setting, but it does not match GitHub in this regard.

I could find no easy setting after about a half hour of research, and didn't think it was worth more time to support ill-formatted markdown, at this time.