### PR TITLE
implement commit linting for conventional-commit rules

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,11 @@
+name: Commit Linter
+on: [pull_request]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v1
+      - uses: wagoid/commitlint-github-action@v1

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [
+      1,
+      'always',
+      [
+        'build',
+        'chore',
+        'ci',
+        'docs',
+        'feat',
+        'fix',
+        'perf',
+        'refactor',
+        'revert',
+        'style',
+        'test'
+      ]
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "private": true,
   "name": "planning-suite-monorepo",
   "devDependencies": {
+    "@commitlint/cli": "^8.2.0",
+    "@commitlint/config-conventional": "^8.2.0",
     "coveralls": "3.0.2",
     "cypress": "^3.1.5",
     "husky": "^3.0.0",
@@ -94,7 +96,8 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lerna run --concurrency 1 --stream precommit"
+      "pre-commit": "lerna run --concurrency 1 --stream precommit",
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   },
   "build_exclude_pattern": "-e !node_modules -e !**/node_modules/**/*"


### PR DESCRIPTION
These changes will enforce conventional commit rules in both github and client-side via husky.

Note: I encountered this bug when trying to use an exclamation point to denote a breaking change: https://github.com/conventional-changelog/commitlint/issues/884