### PR TITLE
fix: single scrollbar on New Project panel

### DIFF
--- a/apps/projects/app/components/Panel/NewProject/NewProject.js
+++ b/apps/projects/app/components/Panel/NewProject/NewProject.js
@@ -69,7 +69,7 @@ const NewProject = () => {
   // already are
   const RepoList = ({ visibleRepos, repoArray }) => {
     if (visibleRepos.length) return (
-      <RadioList
+      <StyledRadioList
         items={repoArray}
         selected={repoSelected}
         onChange={onRepoSelected(repoArray)}
@@ -214,8 +214,17 @@ const ScrollableList = styled.div`
   overflow-y: auto;
   padding-right: 10px;
   margin: 16px 0;
-  // Hack needed to make the scrollable list, since the whole SidePanel is a scrollable container
-  height: calc(100vh - 420px);
+  /* Hack needed to make the scrollable list, since the whole SidePanel is a scrollable container */
+  height: calc(100vh - 428px);
+`
+const StyledRadioList = styled(RadioList)`
+  > * {
+    div {
+      max-width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
 `
 const RepoInfo = styled.div`
   margin: 20px 0;


### PR DESCRIPTION
This PR covers issue #542. The New Project panel only shows one scrollbar, additionally I fixed the issue where an x-axis scrollbar would appear if a project label was too long. Now we do an ellipses if text overflows.

![Screenshot from 2020-01-02 11-31-51](https://user-images.githubusercontent.com/19808076/71688052-043f9500-2d54-11ea-8e35-5ca3b60a3616.png)
