### PR TITLE
fix(tests): fix tests failing because running in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "test:projects": "cd apps/projects && npm test",
     "test:rewards": "cd apps/rewards && npm test",
     "test:tps": "lerna run --scope=@tps/kits-planning-suite --stream test",
-    "test": "lerna run test --no-bail"
+    "test": "lerna run test --no-bail --concurrency=1"
   },
   "dependencies": {
     "ipfs-http-client": "29.1.0",


### PR DESCRIPTION
While previously configuring lerna to run in parallel, it was introduced
a regression that makes test script fail because sharing devchain data,
it was fixed by limiting concurrency to single thread