### PR TITLE
fix: dot voting default decimals value changed from 0 to 18

### DIFF
--- a/apps/dot-voting/app/components/VoteDetails/index.js
+++ b/apps/dot-voting/app/components/VoteDetails/index.js
@@ -20,7 +20,7 @@ const VoteDetails = ({ vote, onVote }) => {
   const { api, appState: { tokenAddress = '' }, connectedAccount } = useAragonApi()
   const [ votingMode, setVotingMode ] = useState(false)
   const [ canIVote, setCanIVote ] = useState(false)
-  const [ decimals, setDecimals ] = useState(0)
+  const [ decimals, setDecimals ] = useState(18)
   const toggleVotingMode = () => setVotingMode(!votingMode)
   const { description, voteId, data: { creator, executionTargetData, type } } = vote
   const { voteWeights, votingPower } = useUserVoteStats(vote)


### PR DESCRIPTION
The PR simply changes the default value of `decimals` in VoteDetails from 0 to 18. This will hopefully solve the issue we see here: https://github.com/AutarkLabs/open-enterprise/issues/1845