### PR TITLE
chore(linting): bump commitlint to v8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "private": true,
   "name": "planning-suite-monorepo",
   "devDependencies": {
-    "@commitlint/cli": "^8.2.0",
-    "@commitlint/config-conventional": "^8.2.0",
+    "@commitlint/cli": "^8.3.4",
+    "@commitlint/config-conventional": "^8.3.4",
     "coveralls": "3.0.2",
     "cypress": "^3.1.5",
     "husky": "^3.0.0",


### PR DESCRIPTION
This allows for the breaking change `!` token in the commit headers