### PR TITLE
Projects: remake issues tab as project detail

### DIFF
--- a/apps/projects/app/Routes.js
+++ b/apps/projects/app/Routes.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import usePathHelpers from '../../../shared/utils/usePathHelpers'
 
-import { Issues, General, Settings } from './components/Content'
+import { ProjectDetail, General, Settings } from './components/Content'
 import IssueDetail from './components/Content/IssueDetail'
 
 export default function Routes({ handleGithubSignIn }) {
@@ -11,8 +11,10 @@ export default function Routes({ handleGithubSignIn }) {
   const { issueId } = parsePath('^/issues/:issueId')
   if (issueId) return <IssueDetail issueId={issueId} />
 
+  const { repoId } = parsePath('^/projects/:repoId')
+  if (repoId) return <ProjectDetail repoId={repoId} />
+
   const { tab } = parsePath('^/:tab')
-  if (tab === 'issues') return <Issues />
   if (tab === 'settings') return <Settings onLogin={handleGithubSignIn} />
 
   return <General />

--- a/apps/projects/app/components/Card/Issue.js
+++ b/apps/projects/app/components/Card/Issue.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
-import usePathHelpers from '../../../../../shared/utils/usePathHelpers'
 
 import {
   Checkbox,
@@ -99,10 +98,9 @@ const Bounty = ({ issue }) => {
 
 Bounty.propTypes = issueShape
 
-const Issue = ({ isSelected, onSelect, ...issue }) => {
+const Issue = ({ isSelected, onClick, onSelect, ...issue }) => {
   const theme = useTheme()
   const { layoutName } = useLayout()
-  const { requestPath } = usePathHelpers()
   const {
     workStatus,
     title,
@@ -128,7 +126,7 @@ const Issue = ({ isSelected, onSelect, ...issue }) => {
               css="text-decoration: none"
               onClick={e => {
                 e.preventDefault()
-                requestPath('/issues/' + issue.id)
+                onClick(issue.id)
               }}
             >
               <IssueTitle theme={theme}>{title}</IssueTitle>
@@ -184,6 +182,7 @@ Issue.propTypes = {
   repo: PropTypes.string.isRequired,
   number: PropTypes.number.isRequired,
   isSelected: PropTypes.bool,
+  onClick: PropTypes.func.isRequired,
   onSelect: PropTypes.func.isRequired,
   workStatus: PropTypes.oneOf([
     undefined,

--- a/apps/projects/app/components/Card/Project.js
+++ b/apps/projects/app/components/Card/Project.js
@@ -45,7 +45,7 @@ const Project = ({
 
   const clickContext = e => {
     e.stopPropagation()
-    requestPath(`/issues?repoId=${repoId}`)
+    requestPath(`/projects/${repoId}`)
   }
 
   return (

--- a/apps/projects/app/components/Content/Filters.js
+++ b/apps/projects/app/components/Content/Filters.js
@@ -34,11 +34,6 @@ const Filters = ({ filters, issues, bountyIssues, disableFilter, disableAllFilte
   const calculateFilters = () => {
     const filterInformation = prepareFilters(issues, bountyIssues)
 
-    const projectBasedFilters = generateFilterNamesAndPaths(
-      filterInformation,
-      'projects',
-      'name'
-    )
     const labelBasedFilters = generateFilterNamesAndPaths(
       filterInformation,
       'labels',
@@ -56,7 +51,6 @@ const Filters = ({ filters, issues, bountyIssues, disableFilter, disableAllFilte
     )
 
     return {
-      ...projectBasedFilters,
       ...labelBasedFilters,
       ...milestoneBasedFilters,
       ...statusBasedFilters,
@@ -109,7 +103,6 @@ const Wrap = styled.div`
 
 Filters.propTypes = {
   filters: PropTypes.shape({
-    projects: PropTypes.object.isRequired,
     labels: PropTypes.object.isRequired,
     milestones: PropTypes.object.isRequired,
     deadlines: PropTypes.object.isRequired,
@@ -125,7 +118,6 @@ Filters.propTypes = {
 
 Filters.defaultProps = {
   filters: {
-    projects: {},
     labels: {},
     milestones: {},
     deadlines: {},

--- a/apps/projects/app/components/Content/IssueDetail/index.js
+++ b/apps/projects/app/components/Content/IssueDetail/index.js
@@ -18,21 +18,24 @@ import DetailsCard from './DetailsCard'
 import BountyCard from './BountyCard'
 import { usePanelManagement } from '../../Panel'
 import usePathHelpers from '../../../../../../shared/utils/usePathHelpers'
+import { useDecoratedRepos } from '../../../context/DecoratedRepos'
 
-function Wrap({ children }) {
+function Wrap({ children, repo }) {
   const { requestPath } = usePathHelpers()
   const { setupNewIssue } = usePanelManagement()
 
   return (
     <>
       <Header
-        primary="Projects"
+        primary={repo && repo.metadata.name}
         secondary={
           <Button mode="strong" icon={<IconPlus />} onClick={setupNewIssue} label="New issue" />
         }
       />
       <Bar>
-        <BackButton onClick={() => requestPath('/issues')} />
+        <BackButton onClick={() => {
+          if (repo) requestPath('/projects/' + repo.data._repo)
+        }} />
       </Bar>
       {children}
     </>
@@ -41,6 +44,14 @@ function Wrap({ children }) {
 
 Wrap.propTypes = {
   children: PropTypes.node.isRequired,
+  repo: PropTypes.shape({
+    data: PropTypes.shape({
+      _repo: PropTypes.string.isRequired,
+    }).isRequired,
+    metadata: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+    }).isRequired,
+  }),
 }
 
 const IssueDetail = ({ issueId }) => {
@@ -53,6 +64,13 @@ const IssueDetail = ({ issueId }) => {
     onError: console.error,
     variables: { id: issueId },
   })
+
+  const repos = useDecoratedRepos()
+  const repo = useMemo(() => {
+    if (!data || !data.node) return null
+    return repos.find(repo => repo.data._repo === data.node.repository.id)
+  }, [ data, repos ])
+
   if (loading) return <Wrap>Loading...</Wrap>
   if (error) return <Wrap>{JSON.stringify(error)}</Wrap>
 
@@ -60,7 +78,7 @@ const IssueDetail = ({ issueId }) => {
   const columnView = layoutName === 'small' || layoutName === 'medium'
 
   return (
-    <Wrap>
+    <Wrap repo={repo}>
       {columnView ? (
         <div css="display: flex; flex-direction: column">
           <div css={`

--- a/apps/projects/app/components/Content/ProjectDetail.js
+++ b/apps/projects/app/components/Content/ProjectDetail.js
@@ -15,6 +15,7 @@ import { Issue } from '../Card'
 import { EmptyWrapper, FilterBar, LoadingAnimation } from '../Shared'
 import { useDecoratedRepos } from '../../context/DecoratedRepos'
 import { usePanelManagement } from '../Panel'
+import usePathHelpers from '../../../../../shared/utils/usePathHelpers'
 
 const sorters = {
   'Name ascending': (i1, i2) =>
@@ -39,6 +40,7 @@ class ProjectDetail extends React.PureComponent {
       loading: PropTypes.bool.isRequired,
       refetch: PropTypes.func,
     }).isRequired,
+    viewIssue: PropTypes.func.isRequired,
     setQuery: PropTypes.func.isRequired,
     setFilters: PropTypes.func.isRequired,
     shapeIssue: PropTypes.func.isRequired,
@@ -247,6 +249,7 @@ class ProjectDetail extends React.PureComponent {
                   isSelected={issue.id in this.state.selectedIssues}
                   key={issue.id}
                   {...issue}
+                  onClick={this.props.viewIssue}
                   onSelect={this.handleIssueSelection}
                 />
               ))}
@@ -304,6 +307,10 @@ const ProjectDetailWrap = ({ repoId, ...props }) => {
     experiences: {},
     statuses: {},
   })
+  const { requestPath } = usePathHelpers()
+  const viewIssue = useCallback(id => {
+    requestPath('/issues/' + id)
+  })
 
   const repos = useDecoratedRepos()
   const repo = useMemo(() => {
@@ -336,6 +343,7 @@ const ProjectDetailWrap = ({ repoId, ...props }) => {
           client={client}
           filters={filters}
           query={query}
+          viewIssue={viewIssue}
           setQuery={setQuery}
           setFilters={setFilters}
           shapeIssue={shapeIssue}

--- a/apps/projects/app/components/Content/ProjectDetail.js
+++ b/apps/projects/app/components/Content/ProjectDetail.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState, useCallback } from 'react'
 import styled from 'styled-components'
 import { useQuery } from '@apollo/react-hooks'
 
@@ -10,10 +10,10 @@ import { compareAsc, compareDesc } from 'date-fns'
 import { initApolloClient } from '../../utils/apollo-client'
 import useShapedIssue from '../../hooks/useShapedIssue'
 import { STATUS } from '../../utils/github'
-import usePathHelpers from '../../../../../shared/utils/usePathHelpers'
 import { getIssuesGQL } from '../../utils/gql-queries.js'
 import { Issue } from '../Card'
-import { EmptyWrapper, FilterBar, LoadingAnimation, Tabs } from '../Shared'
+import { EmptyWrapper, FilterBar, LoadingAnimation } from '../Shared'
+import { useDecoratedRepos } from '../../context/DecoratedRepos'
 import { usePanelManagement } from '../Panel'
 
 const sorters = {
@@ -29,7 +29,7 @@ const sorters = {
 
 const ISSUES_PER_CALL = 100
 
-class Issues extends React.PureComponent {
+class ProjectDetail extends React.PureComponent {
   static propTypes = {
     bountyIssues: PropTypes.array.isRequired,
     filters: PropTypes.object.isRequired,
@@ -39,34 +39,21 @@ class Issues extends React.PureComponent {
       loading: PropTypes.bool.isRequired,
       refetch: PropTypes.func,
     }).isRequired,
-    setDownloadedRepos: PropTypes.func.isRequired,
+    setQuery: PropTypes.func.isRequired,
     setFilters: PropTypes.func.isRequired,
     shapeIssue: PropTypes.func.isRequired,
   }
 
   state = {
     selectedIssues: {},
-    allSelected: false,
     sortBy: 'Newest',
     textFilter: '',
     reload: false,
-    downloadedIssues: [],
+    cachedIssues: [],
   }
 
   deselectAllIssues = () => {
-    this.setState({ selectedIssues: {}, allSelected: false })
-  }
-
-  toggleSelectAll = issuesFiltered => () => {
-    const selectedIssues = {}
-    const allSelected = !this.state.allSelected
-    const reload = !this.state.reload
-    if (!this.state.allSelected) {
-      issuesFiltered.map(this.props.shapeIssue).forEach(
-        issue => (selectedIssues[issue.id] = issue)
-      )
-    }
-    this.setState({ allSelected, selectedIssues, reload })
+    this.setState({ selectedIssues: {} })
   }
 
   handleFiltering = filters => {
@@ -82,7 +69,7 @@ class Issues extends React.PureComponent {
     this.setState(prevState => ({ sortBy, reload: !prevState.reload }))
   }
 
-  applyFilters = issues => {
+  applyFilters = allIssues => {
     const { textFilter } = this.state
     const { filters, bountyIssues } = this.props
 
@@ -91,14 +78,7 @@ class Issues extends React.PureComponent {
       bountyIssueObj[issue.issueNumber] = issue.data.workStatus
     })
 
-    const issuesByProject = issues.filter(issue => {
-      if (Object.keys(filters.projects).length === 0) return true
-      if (Object.keys(filters.projects).indexOf(issue.repository.id) !== -1)
-        return true
-      return false
-    })
-
-    const issuesByLabel = issuesByProject.filter(issue => {
+    const issuesByLabel = allIssues.filter(issue => {
       // if there are no labels to filter by, pass all
       if (Object.keys(filters.labels).length === 0) return true
       // if labelless issues are allowed, let them pass
@@ -186,7 +166,6 @@ class Issues extends React.PureComponent {
 
   disableAllFilters = () => {
     this.props.setFilters({
-      projects: {},
       labels: {},
       milestones: {},
       deadlines: {},
@@ -195,16 +174,14 @@ class Issues extends React.PureComponent {
     })
   }
 
-  filterBar = (issues, issuesFiltered) => {
+  filterBar = (allIssues, filteredIssues) => {
     return (
       <FilterBar
         setParentFilters={this.props.setFilters}
         filters={this.props.filters}
         sortBy={this.state.sortBy}
-        handleSelectAll={this.toggleSelectAll(issuesFiltered)}
-        allSelected={this.state.allSelected}
-        issues={issues}
-        issuesFiltered={issuesFiltered}
+        issues={allIssues}
+        issuesFiltered={filteredIssues}
         handleFiltering={this.handleFiltering}
         handleSorting={this.handleSorting}
         bountyIssues={this.props.bountyIssues}
@@ -247,76 +224,23 @@ class Issues extends React.PureComponent {
     </StyledIssues>
   )
 
-  /*
-   Data obtained from github API is data.{repo}.issues.[nodes] and it needs
-   flattening into one simple array of issues  before it can be used
-
-   Returns array of issues and object of repos numbers: how many issues
-   in repo in total, how many downloaded, how many to fetch next time
-   (for "show more")
-  */
-  flattenIssues = data => {
-    let downloadedIssues = []
-    const downloadedRepos = {}
-
-    Object.keys(data).forEach(nodeName => {
-      const repo = data[nodeName]
-
-      downloadedRepos[repo.id] = {
-        downloadedCount: repo.issues.nodes.length,
-        totalCount: repo.issues.totalCount,
-        fetch: ISSUES_PER_CALL,
-        hasNextPage: repo.issues.pageInfo.hasNextPage,
-        endCursor: repo.issues.pageInfo.endCursor,
-      }
-      downloadedIssues = downloadedIssues.concat(...repo.issues.nodes)
-    })
-
-    if (this.state.downloadedIssues.length > 0) {
-      downloadedIssues = downloadedIssues.concat(this.state.downloadedIssues)
-    }
-
-    return { downloadedIssues, downloadedRepos }
-  }
-
-  showMoreIssues = (downloadedIssues, downloadedRepos) => {
-    let newDownloadedRepos = { ...downloadedRepos }
-
-    Object.keys(downloadedRepos).forEach(repoId => {
-      newDownloadedRepos[repoId].showMore = downloadedRepos[repoId].hasNextPage
-    })
-    this.props.setDownloadedRepos(newDownloadedRepos)
-    this.setState({
-      downloadedIssues,
-    })
-  }
-
   render() {
+    const { cachedIssues } = this.state
     const { data, loading, error, refetch } = this.props.graphqlQuery
 
     if (loading) return this.queryLoading()
-
     if (error) return this.queryError(error, refetch)
 
-    // first, flatten data structure into array of issues
-    const { downloadedIssues, downloadedRepos } = this.flattenIssues(data)
-
-    // then apply filtering
-    const issuesFiltered = this.applyFilters(downloadedIssues)
-
-    // then determine whether any shown repos have more issues to fetch
-    const moreIssuesToShow =
-      Object.keys(downloadedRepos).filter(
-        repoId => downloadedRepos[repoId].hasNextPage
-      ).length > 0
+    const allIssues = [ ...cachedIssues, ...data.repository.issues.nodes ]
+    const filteredIssues = this.applyFilters(allIssues)
 
     return (
       <StyledIssues>
-        {this.filterBar(downloadedIssues, issuesFiltered)}
+        {this.filterBar(allIssues, filteredIssues)}
 
         <IssuesScrollView>
           <ScrollWrapper>
-            {issuesFiltered.map(this.props.shapeIssue)
+            {filteredIssues.map(this.props.shapeIssue)
               .sort(sorters[this.state.sortBy])
               .map(issue => (
                 <Issue
@@ -329,13 +253,16 @@ class Issues extends React.PureComponent {
           </ScrollWrapper>
 
           <div style={{ textAlign: 'center' }}>
-            {moreIssuesToShow && (
+            {data.repository.issues.pageInfo.hasNextPage && (
               <Button
                 style={{ margin: '12px 0 30px 0' }}
                 mode="secondary"
-                onClick={() =>
-                  this.showMoreIssues(downloadedIssues, downloadedRepos)
-                }
+                onClick={() => {
+                  this.setState({ cachedIssues: allIssues })
+                  this.props.setQuery({
+                    after: data.repository.issues.pageInfo.endCursor,
+                  })
+                }}
               >
                 Show More
               </Button>
@@ -347,31 +274,30 @@ class Issues extends React.PureComponent {
   }
 }
 
-const IssuesQuery = ({ client, query, ...props }) => {
-  const graphqlQuery = useQuery(query, { client, onError: console.error })
-  return <Issues graphqlQuery={graphqlQuery} {...props} />
+const ProjectDetailQuery = ({ client, query, ...props }) => {
+  const graphqlQuery = useQuery(
+    getIssuesGQL(query),
+    { client, onError: console.error }
+  )
+  return <ProjectDetail graphqlQuery={graphqlQuery} {...props} />
 }
 
-IssuesQuery.propTypes = {
+ProjectDetailQuery.propTypes = {
   client: PropTypes.object.isRequired,
   query: PropTypes.object.isRequired,
 }
 
-const IssuesWrap = props => {
+const ProjectDetailWrap = ({ repoId, ...props }) => {
   const { appState } = useAragonApi()
   const {
-    repos,
     issues = [],
     github = { status : STATUS.INITIAL },
   } = appState
   const shapeIssue = useShapedIssue()
-  const { query: { repoId } } = usePathHelpers()
   const { setupNewIssue } = usePanelManagement()
   const [ client, setClient ] = useState(null)
-  const [ downloadedRepos, setDownloadedRepos ] = useState({})
-  const [ query, setQuery ] = useState(null)
+  const [ query, setQueryRaw ] = useState({ repoId, count: ISSUES_PER_CALL })
   const [ filters, setFilters ] = useState({
-    projects: repoId ? { [repoId]: true } : {},
     labels: {},
     milestones: {},
     deadlines: {},
@@ -379,40 +305,14 @@ const IssuesWrap = props => {
     statuses: {},
   })
 
-  // build params for GQL query, each repo to fetch has number of items to download,
-  // and a cursor if there are 100+ issues and "Show More" was clicked.
-  useEffect(() => {
-    // don't set invalid query during initial data sync
-    if (repos.length === 0) return
+  const repos = useDecoratedRepos()
+  const repo = useMemo(() => {
+    return repos.find(({ data }) => data._repo === repoId)
+  }, [repos])
 
-    let reposQueryParams = {}
-
-    if (Object.keys(downloadedRepos).length > 0) {
-      Object.keys(downloadedRepos).forEach(repoId => {
-        if (downloadedRepos[repoId].hasNextPage)
-          reposQueryParams[repoId] = downloadedRepos[repoId]
-      })
-    } else {
-      if (Object.keys(filters.projects).length > 0) {
-        Object.keys(filters.projects).forEach(repoId => {
-          reposQueryParams[repoId] = {
-            fetch: ISSUES_PER_CALL,
-            showMore: false,
-          }
-        })
-      } else {
-        repos.forEach(repo => {
-          const repoId = repo.data._repo
-          reposQueryParams[repoId] = {
-            fetch: ISSUES_PER_CALL,
-            showMore: false,
-          }
-        })
-      }
-    }
-
-    setQuery(getIssuesGQL(reposQueryParams))
-  }, [ downloadedRepos, filters, repos ])
+  const setQuery = useCallback(({ after }) => {
+    setQueryRaw({ ...query, after })
+  }, [])
 
   useEffect(() => {
     setClient(github.token ? initApolloClient(github.token) : null)
@@ -421,23 +321,22 @@ const IssuesWrap = props => {
   return (
     <>
       <Header
-        primary="Projects"
+        primary={repo && repo.metadata.name || 'Projects'}
         secondary={
           <Button mode="strong" icon={<IconPlus />} onClick={setupNewIssue} label="New issue" />
         }
       />
-      <Tabs />
       {!query ? (
         'Loading...'
       ) : !client ? (
         'You must sign into GitHub to view issues.'
       ) : (
-        <IssuesQuery
+        <ProjectDetailQuery
           bountyIssues={issues}
           client={client}
           filters={filters}
           query={query}
-          setDownloadedRepos={setDownloadedRepos}
+          setQuery={setQuery}
           setFilters={setFilters}
           shapeIssue={shapeIssue}
           {...props}
@@ -445,6 +344,10 @@ const IssuesWrap = props => {
       )}
     </>
   )
+}
+
+ProjectDetailWrap.propTypes = {
+  repoId: PropTypes.string.isRequired,
 }
 
 const StyledIssues = styled.div`
@@ -485,4 +388,4 @@ const recursiveDeletePathFromObject = (path, object) => {
 }
 
 // eslint-disable-next-line import/no-unused-modules
-export default IssuesWrap
+export default ProjectDetailWrap

--- a/apps/projects/app/components/Content/index.js
+++ b/apps/projects/app/components/Content/index.js
@@ -1,6 +1,6 @@
-import Issues from './Issues'
+import ProjectDetail from './ProjectDetail'
 import General from './General'
 import Settings from './Settings'
 
-export { Issues, General, Settings }
+export { ProjectDetail, General, Settings }
 

--- a/apps/projects/app/components/Shared/Tabs.js
+++ b/apps/projects/app/components/Shared/Tabs.js
@@ -1,15 +1,11 @@
 import React from 'react'
 import usePathHelpers from '../../../../../shared/utils/usePathHelpers'
 import { Tabs as AragonTabs } from '@aragon/ui'
-import { useAragonApi } from '../../api-react'
+
+const tabs = [ 'General', 'Settings' ]
 
 export default function Tabs() {
   const { parsePath, requestPath } = usePathHelpers()
-  const { appState: { repos } } = useAragonApi()
-
-  const tabs = ['General']
-  if (repos.length) tabs.push('Issues')
-  tabs.push('Settings')
 
   const { tab } = parsePath('^/:tab')
 

--- a/apps/projects/app/utils/gql-queries.js
+++ b/apps/projects/app/utils/gql-queries.js
@@ -33,16 +33,15 @@ const issueAttributes = `
   url
 `
 
-export const getIssuesGQL = repos => {
-  const queries = Object.keys(repos).map((repoId, i) => `
-    node${i}: node(id: "${repoId}") {
-      id
+export const getIssuesGQL = ({ repoId, count, after }) => gql`
+  query getIssuesForRepo {
+    repository: node(id: "${repoId}") {
       ... on Repository {
         issues(
           states:OPEN,
-          first: ${repos[repoId].fetch},
-          ${repos[repoId].showMore ? `after: "${repos[repoId].endCursor}",` : ''}
-         orderBy: {field: CREATED_AT, direction: DESC}
+          first: ${count},
+          ${after ? `after: "${after}",` : ''}
+          orderBy: {field: CREATED_AT, direction: DESC}
         ) {
           totalCount
           pageInfo {
@@ -52,12 +51,10 @@ export const getIssuesGQL = repos => {
           nodes { ${issueAttributes} }
         }
       }
-    }`
-  )
-  return gql`query getIssuesForRepos {
-    ${queries.join('')}
-  }`
-}
+    }
+  }
+`
+
 
 export const GET_ISSUE = gql`
   query GetIssue($id: ID!) {

--- a/shared/utils/usePathHelpers.js
+++ b/shared/utils/usePathHelpers.js
@@ -1,9 +1,6 @@
 import React from 'react'
 import { usePath } from '@aragon/api-react'
 
-const SEARCH_REGEX = /\?(.+)($|#)/ // everything between ? and end-of-line or a hash sign
-const SEARCH_PARAM_REGEX = /([a-zA-Z0-9]+)=([a-zA-Z0-9=]+)/
-
 export default function usePathHelpers() {
   const [ path, requestPath ] = usePath()
 
@@ -33,21 +30,6 @@ export default function usePathHelpers() {
     return groups
   }, [ path, requestPath ])
 
-  const [ , search ] = path.match(SEARCH_REGEX) || []
-  const query = React.useMemo(() => {
-    if (!search) return {}
-
-    return search.split('&').reduce(
-      (acc, param) => {
-        const [ , key, value ] = param.match(SEARCH_PARAM_REGEX)
-        acc[key] = value
-        return acc
-      },
-      {}
-    )
-  }, [search])
-
-
-  return { parsePath, requestPath, query }
+  return { parsePath, requestPath }
 }
 


### PR DESCRIPTION
fixes #1865

Rather than having an Issues tab at the top that, when visited, shows all issues for all projects, you can now only see issues for one project at a time.

This has a few benefits:

* A simpler filtering experience: three filters instead of four.
* Less wasted vertical space: the filter bar now contains a back button, and there's no need to show tabs. Your list of issues displays closer to the top of the page.
* Code maintainability: expect faster changes to projects, now that we were able to simplify the complex logic resulting from multi-project filtering.

I recommend viewing this diff [with indentation changes hidden](https://github.com/AutarkLabs/open-enterprise/pull/1902/files?w=1)

## Screenshot

Three quirks to note:

1. When clicking through from a project to an issue, the heading of the page disappears momentarily – this would be awkward to code around, and I don't think it's worth it. The reason this happens is because it is coded in a way that keeps the URL minimal (project detail at `/projects/:projectId`, issue detail at `/issues/:issueId`), and ensures that refreshing the page will still load data correctly and show the correct heading

2. When you apply filters, then select an issue, then click "Back", your filters are lost – this has two causes: 1. We are not currently implementing filtering via the URL, 2. Even if we were, aragonAPI does not support true "go back" behavior; we could hack something together ourselves, but it would work imperfectly

3. The "Show More" behavior has not changed – you'll see how clumsy it is for large projects in the screen recording below

![ProjectDetail 2020-01-21 at 17 19 18](https://user-images.githubusercontent.com/221614/72848253-3452c780-3c72-11ea-8220-3b612fffd08b.gif)
