### PR TITLE
test(bounties): remove unnecessary wallet dependency

### DIFF
--- a/shared/integrations/StandardBounties/package.json
+++ b/shared/integrations/StandardBounties/package.json
@@ -35,7 +35,6 @@
     "truffle": "^5.0.22"
   },
   "devDependencies": {
-    "truffle-hdwallet-provider": "0.0.3",
     "cryptiles": ">=4.1.2",
     "sshpk": ">=1.13.2"
   }

--- a/shared/integrations/StandardBounties/truffle-config.js
+++ b/shared/integrations/StandardBounties/truffle-config.js
@@ -1,4 +1,3 @@
-const HDWalletProvider = require('truffle-hdwallet-provider')
 const fs = require('fs')
 
 // First read in the secrets.json to get our mnemonic
@@ -44,11 +43,6 @@ module.exports = {
       // gas
       // gasPrice
       // from - default address to use for any transaction Truffle makes during migrations
-    },
-    ropsten: {
-      provider: new HDWalletProvider(mnemonic, 'https://ropsten.infura.io'),
-      network_id: '3',
-      gas: 4600000
     },
     testrpc: {
       network_id: 'default',


### PR DESCRIPTION
The truffle hd wallet provider in the Standard Bounties subrepo is only
needed for use on the ropsten testnet. Since we aren't deploying
anything to Ropsten currently, I'm removing it since it's currently
crashing truffle during test deploys