### PR TITLE
fix: add metadata to new vote

### DIFF
--- a/apps/dot-voting/app/components/Panels/NewVote.js
+++ b/apps/dot-voting/app/components/Panels/NewVote.js
@@ -80,7 +80,7 @@ const NewVote = ({ onClose }) => {
       description,
       Object.values(options).filter(o => o !== '')
     )
-    api.newVote(callscript, '').toPromise()
+    api.newVote(callscript, description).toPromise()
     onClose()
   }
 


### PR DESCRIPTION
This PR simply adds the vote description to the metadata field in the newVote contract call on the Dot Voting app