### PR TITLE
fix(dot-voting): smooth transition for side panel

### DIFF
--- a/apps/dot-voting/app/components/Panels/NewVote.js
+++ b/apps/dot-voting/app/components/Panels/NewVote.js
@@ -5,6 +5,7 @@ import {
   Field,
   IconClose,
   TextInput,
+  useSidePanel,
   useTheme,
 } from '@aragon/ui'
 import { Form, OptionsInput } from '../../../../../shared/ui'
@@ -35,6 +36,7 @@ ErrorMessage.propTypes = {
 }
 
 const NewVote = ({ onClose }) => {
+  const { readyToFocus } = useSidePanel()
   const { api } = useAragonApi()
   const [ description, setDescription ] = useState()
   const [ options, setOptions ] = useState({ '0':'' })
@@ -102,7 +104,7 @@ const NewVote = ({ onClose }) => {
           onChange={e => setDescription(e.target.value)}
           placeholder="Add your description here."
           wide
-          autofocus
+          autofocus={readyToFocus}
         />
       </Field>
       <Field


### PR DESCRIPTION
This fixes the issue where the side panel would just appear instead of doing a smooth transition. Turns out this is caused by the `autofocus` parameter on the Description field in the NewVote component. Aragon has accounted for this problem though, we just need to get `readyToFocus` from the `useSidePanel()` hook and pass it to the `autofocus` parameter.