### PR TITLE
Disabled react-axe

### DIFF
--- a/apps/dot-voting/app/index.js
+++ b/apps/dot-voting/app/index.js
@@ -2,13 +2,10 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 
-// eslint-disable-next-line no-process-env
-if (process.env.NODE_ENV !== 'production') {
-  // eslint-disable-next-line global-require
-  const axe = require('react-axe')
-  // eslint-disable-next-line no-magic-numbers
-  axe(React, ReactDOM, 1000)
-}
+// if (process.env.NODE_ENV !== 'production') {
+//   var axe = require('react-axe')
+//   axe(React, ReactDOM, 1000)
+// }
 
 import App from './App'
 

--- a/apps/projects/app/index.js
+++ b/apps/projects/app/index.js
@@ -2,16 +2,15 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 
-// stub out axe; not interested in dealing with this noise rn
-if (process.env.NODE_ENV !== 'production') {
-  var axe = require('react-axe')
-  axe(React, ReactDOM, 1000, {
-    rules: [{
-      id: 'skip-link',
-      enabled: false,
-    }]
-  })
-}
+// if (process.env.NODE_ENV !== 'production') {
+//   var axe = require('react-axe')
+//   axe(React, ReactDOM, 1000, {
+//     rules: [{
+//       id: 'skip-link',
+//       enabled: false,
+//     }]
+//   })
+// }
 
 import { AragonApi } from './api-react'
 import appStateReducer from './app-state-reducer'


### PR DESCRIPTION
react-axe was enabled to find a11y issues. Even in production mode it highlights many issues we can't fix right now - and it has impact on performance. This PR disables it completely.