### PR TITLE
feat(projects): add proper "Back" to IssueDetail

### DIFF
--- a/apps/projects/app/components/Content/IssueDetail/index.js
+++ b/apps/projects/app/components/Content/IssueDetail/index.js
@@ -21,7 +21,7 @@ import usePathHelpers from '../../../../../../shared/utils/usePathHelpers'
 import { useDecoratedRepos } from '../../../context/DecoratedRepos'
 
 function Wrap({ children, repo }) {
-  const { requestPath } = usePathHelpers()
+  const { goBack } = usePathHelpers()
   const { setupNewIssue } = usePanelManagement()
 
   return (
@@ -34,7 +34,7 @@ function Wrap({ children, repo }) {
       />
       <Bar>
         <BackButton onClick={() => {
-          if (repo) requestPath('/projects/' + repo.data._repo)
+          if (repo) goBack({ fallback: '/projects/' + repo.data._repo })
         }} />
       </Bar>
       {children}

--- a/shared/utils/usePathHelpers.js
+++ b/shared/utils/usePathHelpers.js
@@ -1,8 +1,26 @@
 import React from 'react'
 import { usePath } from '@aragon/api-react'
 
+const history = []
+
 export default function usePathHelpers() {
   const [ path, requestPath ] = usePath()
+
+  React.useEffect(() => {
+    if (path !== history[history.length - 1]) {
+      history.push(path)
+    }
+  }, [path])
+
+  // Since goBack is not supported in aragonAPI, we do not have access to
+  // actual browser history. If the user refreshes their page then fires a
+  // `goBack` action, we will have nothing in our custom `history` array.
+  // The `fallback` option allows us to work around this.
+  const goBack = React.useCallback(({ fallback = '/' }) => {
+    history.pop() // remove current page, forget about it (goForward not supported)
+    const prev = history.pop()
+    requestPath(prev || fallback)
+  }, [requestPath])
 
   // accepts a pattern like '/budgets/:id', where ':id' is a named parameter
   // redirects to '/' if the current path doesn't match at all
@@ -30,6 +48,6 @@ export default function usePathHelpers() {
     return groups
   }, [ path, requestPath ])
 
-  return { parsePath, requestPath }
+  return { goBack, parsePath, requestPath }
 }
 


### PR DESCRIPTION
If you get to the IssueDetail page from the Bounties tab, clicking "Back" will now send you back to it, rather than to ProjectDetail

If you visit an IssueDetail page directly, or refresh your browser on an IssueDetail page, clicking "Back" will still send you to ProjectDetail

This has been added in a way that will be easy to use in other places around Autark apps

![goBack to Bounties tab 2020-01-24 at 9 05 29](https://user-images.githubusercontent.com/221614/73074952-bf0d0f80-3e88-11ea-909c-764199a4381a.gif)
