### PR TITLE
fix(projects): ignore bounties made before Nov 26

### DIFF
--- a/apps/projects/app/context/BountyIssues.js
+++ b/apps/projects/app/context/BountyIssues.js
@@ -25,6 +25,12 @@ export function BountyIssuesProvider(props) {
   const [ bountyIssues, setBountyIssues ] = React.useState([])
   const shapeIssue = useShapedIssue()
 
+  const issueIds = React.useMemo(() => {
+    // old versions of the Projects app did not store issueId on ipfs
+    // we filter out such issues; they are not supported by this function
+    return issues.map(i => i.data.issueId).filter(i => i)
+  }, [issues])
+
   React.useEffect(() => {
     if (!github.token) return
 
@@ -34,7 +40,7 @@ export function BountyIssuesProvider(props) {
       },
     })
 
-    client.request(getIssues(issues.map(i => i.data.issueId)))
+    client.request(getIssues(issueIds))
       .then(({ nodes }) => {
         const now = new Date()
         setBountyIssues(nodes.map(shapeIssue).sort((a, b) => {
@@ -50,7 +56,7 @@ export function BountyIssuesProvider(props) {
         }))
       })
       .catch(console.error)
-  }, [ github.token, issues ])
+  }, [ github.token, issueIds ])
 
   return <BountyIssuesContext.Provider value={bountyIssues} {...props} />
 }


### PR DESCRIPTION
Bounties created before Nov 26 will not have their `issueId` stored in IPFS and can therefore not be shown on the new Bounties tab

For DAOs that have such bounties, our old logic caused _no_ bounties to be shown on the Bounties tab. This will allow newer bounties for such DAOs to be shown, while gracefully ignoring older bounties