### PR TITLE
fix(projects): use main component with emptywrapper

### DIFF
--- a/apps/projects/app/App.js
+++ b/apps/projects/app/App.js
@@ -101,9 +101,11 @@ const App = () => {
   const noop = () => {}
   if (githubLoading) {
     return (
-      <EmptyWrapper>
-        <LoadingAnimation />
-      </EmptyWrapper>
+      <Main theme={appearance}>
+        <EmptyWrapper>
+          <LoadingAnimation />
+        </EmptyWrapper>
+      </Main>
     )
   } else if (github.status === STATUS.INITIAL) {
     return (


### PR DESCRIPTION
One component wasn't wrapped in a `Main` component so it wouldn't support dark mode