### PR TITLE
Projects: improve querying behavior

### DIFF
--- a/apps/projects/app/App.js
+++ b/apps/projects/app/App.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { ApolloProvider } from 'react-apollo'
+import { ApolloProvider } from '@apollo/react-hooks'
 
 import { useAragonApi } from './api-react'
 import { Main } from '@aragon/ui'

--- a/apps/projects/app/Routes.js
+++ b/apps/projects/app/Routes.js
@@ -4,15 +4,20 @@ import usePathHelpers from '../../../shared/utils/usePathHelpers'
 
 import { Bounties, General, ProjectDetail, Settings } from './components/Content'
 import IssueDetail from './components/Content/IssueDetail'
+import { useDecoratedRepos } from './context/DecoratedRepos'
 
 export default function Routes({ handleGithubSignIn }) {
   const { parsePath } = usePathHelpers()
+  const repos = useDecoratedRepos()
 
   const { issueId } = parsePath('^/issues/:issueId')
   if (issueId) return <IssueDetail issueId={issueId} />
 
   const { repoId } = parsePath('^/projects/:repoId')
-  if (repoId) return <ProjectDetail repoId={repoId} />
+  const repo = React.useMemo(() => {
+    return repos.find(r => r.data._repo === repoId)
+  }, [ repos, repoId ])
+  if (repo) return <ProjectDetail repo={repo} />
 
   const { tab } = parsePath('^/:tab')
   if (tab === 'bounties') return <Bounties />

--- a/apps/projects/app/Routes.js
+++ b/apps/projects/app/Routes.js
@@ -10,14 +10,14 @@ export default function Routes({ handleGithubSignIn }) {
   const { parsePath } = usePathHelpers()
   const repos = useDecoratedRepos()
 
-  const { issueId } = parsePath('^/issues/:issueId')
-  if (issueId) return <IssueDetail issueId={issueId} />
-
   const { repoId } = parsePath('^/projects/:repoId')
   const repo = React.useMemo(() => {
     return repos.find(r => r.data._repo === repoId)
   }, [ repos, repoId ])
   if (repo) return <ProjectDetail repo={repo} />
+
+  const { issueId } = parsePath('^/issues/:issueId')
+  if (issueId) return <IssueDetail issueId={issueId} />
 
   const { tab } = parsePath('^/:tab')
   if (tab === 'bounties') return <Bounties />

--- a/apps/projects/app/components/Content/Bounties.js
+++ b/apps/projects/app/components/Content/Bounties.js
@@ -188,7 +188,18 @@ IssueColumns.propTypes = {
 }
 
 const Bounties = () => {
-  const issues = useBountyIssues()
+  const now = new Date()
+  const issues = useBountyIssues().sort((a, b) => {
+    //If a deadline has expired, most recent deadline first
+    //If a deadline upcoming, closest to the deadline first
+    let aDate = new Date(a.deadline)
+    let bDate = new Date(b.deadline)
+    if (aDate < now || bDate < now) {
+      aDate = now - aDate
+      bDate = now - bDate
+    }
+    return aDate - bDate
+  })
 
   if (issues.length === 0) {
     return (

--- a/apps/projects/app/components/Content/Filters.js
+++ b/apps/projects/app/components/Content/Filters.js
@@ -5,10 +5,11 @@ import { Button, Text, useTheme } from '@aragon/ui'
 
 import FilterTile from './FilterTile'
 import { prepareFilters } from '../Shared/FilterBar'
-import { issueShape } from '../../utils/shapes.js'
+import { issueShape, repoShape } from '../../utils/shapes.js'
 
-const Filters = ({ filters, issues, bountyIssues, disableFilter, disableAllFilters, style }) => {
+const Filters = ({ filters, issues, bountyIssues, disableFilter, disableAllFilters, repo, style }) => {
   const theme = useTheme()
+  const filterInformation = prepareFilters(issues, bountyIssues, repo)
 
   const generateFilterNamesAndPaths = (filterInformation, type, textFieldToUse) => {
     const appliedFilters = {}
@@ -32,8 +33,6 @@ const Filters = ({ filters, issues, bountyIssues, disableFilter, disableAllFilte
     to make it easier to deselect filters from this view without multiple state objects
   */
   const calculateFilters = () => {
-    const filterInformation = prepareFilters(issues, bountyIssues)
-
     const labelBasedFilters = generateFilterNamesAndPaths(
       filterInformation,
       'labels',
@@ -70,7 +69,7 @@ const Filters = ({ filters, issues, bountyIssues, disableFilter, disableAllFilte
             key={pathToDisableFilter.join('')}
             text={alias}
             disableFilter={() =>
-              disableFilter(pathToDisableFilter)
+              disableFilter(pathToDisableFilter, filterInformation)
             }
           />
         )
@@ -112,6 +111,7 @@ Filters.propTypes = {
   disableFilter: PropTypes.func.isRequired,
   disableAllFilters: PropTypes.func.isRequired,
   style: PropTypes.object,
+  repo: repoShape,
 }
 
 Filters.defaultProps = {

--- a/apps/projects/app/components/Content/Filters.js
+++ b/apps/projects/app/components/Content/Filters.js
@@ -105,8 +105,6 @@ Filters.propTypes = {
   filters: PropTypes.shape({
     labels: PropTypes.object.isRequired,
     milestones: PropTypes.object.isRequired,
-    deadlines: PropTypes.object.isRequired,
-    experiences: PropTypes.object.isRequired,
     statuses: PropTypes.object.isRequired,
   }),
   issues: PropTypes.arrayOf(issueShape).isRequired,
@@ -120,8 +118,6 @@ Filters.defaultProps = {
   filters: {
     labels: {},
     milestones: {},
-    deadlines: {},
-    experiences: {},
     statuses: {},
   },
   issues: [],

--- a/apps/projects/app/components/Content/Filters.js
+++ b/apps/projects/app/components/Content/Filters.js
@@ -38,11 +38,6 @@ const Filters = ({ filters, issues, bountyIssues, disableFilter, disableAllFilte
       'labels',
       'name'
     )
-    const milestoneBasedFilters = generateFilterNamesAndPaths(
-      filterInformation,
-      'milestones',
-      'title'
-    )
     const statusBasedFilters = generateFilterNamesAndPaths(
       filterInformation,
       'statuses',
@@ -51,7 +46,6 @@ const Filters = ({ filters, issues, bountyIssues, disableFilter, disableAllFilte
 
     return {
       ...labelBasedFilters,
-      ...milestoneBasedFilters,
       ...statusBasedFilters,
     }
   }
@@ -103,7 +97,6 @@ const Wrap = styled.div`
 Filters.propTypes = {
   filters: PropTypes.shape({
     labels: PropTypes.object.isRequired,
-    milestones: PropTypes.object.isRequired,
     statuses: PropTypes.object.isRequired,
   }),
   issues: PropTypes.arrayOf(issueShape).isRequired,
@@ -117,7 +110,6 @@ Filters.propTypes = {
 Filters.defaultProps = {
   filters: {
     labels: {},
-    milestones: {},
     statuses: {},
   },
   issues: [],

--- a/apps/projects/app/components/Content/ProjectDetail.js
+++ b/apps/projects/app/components/Content/ProjectDetail.js
@@ -278,10 +278,11 @@ class ProjectDetail extends React.PureComponent {
 }
 
 const ProjectDetailQuery = ({ client, query, ...props }) => {
-  const graphqlQuery = useQuery(
-    getIssuesGQL(query),
-    { client, onError: console.error }
-  )
+  const graphqlQuery = useQuery(getIssuesGQL, {
+    client,
+    variables: query,
+    onError: console.error,
+  })
   return <ProjectDetail graphqlQuery={graphqlQuery} {...props} />
 }
 

--- a/apps/projects/app/components/Content/ProjectDetail.js
+++ b/apps/projects/app/components/Content/ProjectDetail.js
@@ -151,8 +151,6 @@ class ProjectDetail extends React.PureComponent {
     this.props.setFilters({
       labels: {},
       milestones: {},
-      deadlines: {},
-      experiences: {},
       statuses: {},
     })
   }
@@ -282,8 +280,6 @@ const ProjectDetailWrap = ({ repo, ...props }) => {
   const [ filters, setFilters ] = useState({
     labels: {},
     milestones: {},
-    deadlines: {},
-    experiences: {},
     statuses: {},
   })
   const { requestPath } = usePathHelpers()

--- a/apps/projects/app/components/Content/ProjectDetail.js
+++ b/apps/projects/app/components/Content/ProjectDetail.js
@@ -289,10 +289,19 @@ class ProjectDetail extends React.PureComponent {
 
                       if (!fetchMoreResult) return prev
 
-                      return Object.assign({}, prev, {
-                        repository: { ...prev.repository, ...fetchMoreResult.repository }
-                      })
-
+                      return {
+                        ...fetchMoreResult,
+                        repository: {
+                          ...fetchMoreResult.repository,
+                          issues: {
+                            ...fetchMoreResult.repository.issues,
+                            nodes: [
+                              ...prev.repository.issues.nodes,
+                              ...fetchMoreResult.repository.issues.nodes,
+                            ]
+                          },
+                        }
+                      }
                     },
                   })
                 }}
@@ -365,7 +374,6 @@ const ProjectDetailWrap = ({ repo, ...props }) => {
     }
   }
   `
-
   /*
   notifyOnNetworkStatusChange: true,
   onError: console.error,

--- a/apps/projects/app/components/Content/ProjectDetail.js
+++ b/apps/projects/app/components/Content/ProjectDetail.js
@@ -3,10 +3,10 @@ import React, { useState, useCallback } from 'react'
 import styled from 'styled-components'
 import { useQuery } from '@apollo/react-hooks'
 
-import { useAragonApi } from '../../api-react'
 import { Button, GU, Header, IconPlus, Text } from '@aragon/ui'
 
 import useShapedIssue from '../../hooks/useShapedIssue'
+import { useBountyIssues } from '../../context/BountyIssues'
 import { SEARCH_ISSUES } from '../../utils/gql-queries.js'
 import { Issue } from '../Card'
 import { FilterBar, LoadingAnimation } from '../Shared'
@@ -265,8 +265,9 @@ class ProjectDetail extends React.PureComponent {
 }
 
 const ProjectDetailWrap = ({ repo, ...props }) => {
-  const { appState } = useAragonApi()
-  const { issues = [] } = appState
+  const bountyIssues = useBountyIssues().filter(issue =>
+    issue.repoId === repo.data._repo
+  )
   const shapeIssue = useShapedIssue()
   const { setupNewIssue } = usePanelManagement()
   const [ query, setQueryRaw ] = useState({
@@ -308,7 +309,7 @@ const ProjectDetailWrap = ({ repo, ...props }) => {
         }
       />
       <ProjectDetail
-        bountyIssues={issues}
+        bountyIssues={bountyIssues}
         filters={filters}
         graphqlQuery={graphqlQuery}
         viewIssue={viewIssue}
@@ -323,6 +324,9 @@ const ProjectDetailWrap = ({ repo, ...props }) => {
 
 ProjectDetailWrap.propTypes = {
   repo: PropTypes.shape({
+    data: PropTypes.shape({
+      _repo: PropTypes.string,
+    }),
     metadata: PropTypes.shape({
       name: PropTypes.string,
       owner: PropTypes.string,

--- a/apps/projects/app/components/Panel/NewProject/NewProject.js
+++ b/apps/projects/app/components/Panel/NewProject/NewProject.js
@@ -12,7 +12,7 @@ import noResultsSvg from '../../../assets/noResults.svg'
 import { FormField, FieldTitle } from '../../Form'
 import { STATUS } from '../../../utils/github'
 
-const disableDecoupledProjects = false
+const disableDecoupledProjects = true
 
 const RepoList = ({
   filter,

--- a/apps/projects/app/components/Shared/FilterBar/FilterBar.js
+++ b/apps/projects/app/components/Shared/FilterBar/FilterBar.js
@@ -289,7 +289,7 @@ const FilterBar = ({
   const rightFBRef = useRef(null)
   const activeFilters = () => {
     let count = 0
-    const types = [ 'labels', 'milestones', 'statuses' ]
+    const types = [ 'labels', 'statuses' ]
     types.forEach(t => count += Object.keys(filters[t]).length)
     return count
   }
@@ -395,43 +395,6 @@ const FilterBar = ({
     filtersData: PropTypes.object.isRequired,
   }
 
-  const FilterByMilestone = ({ filters, filtersData }) => (
-    <FilterDropDown
-      caption="Milestones"
-      enabled={Object.keys(filtersData.milestones).length > 0}
-    >
-      {Object.keys(filtersData.milestones)
-        .sort((m1, m2) => {
-          if (m1 === 'milestoneless') return -1
-          if (m2 === 'milestoneless') return 1
-          return filtersData.milestones[m1].title <
-        filtersData.milestones[m2].title
-            ? -1
-            : 1
-        })
-        .map(id => (
-          <FilterMenuItem
-            key={id}
-            onClick={filter('milestones', id)}
-          >
-            <div>
-              <Checkbox
-                onChange={noop}
-                checked={id in filters.milestones}
-              />
-            </div>
-            <ActionLabel>
-              {filtersData.milestones[id].title}
-            </ActionLabel>
-          </FilterMenuItem>
-        ))}
-    </FilterDropDown>
-  )
-  FilterByMilestone.propTypes = {
-    filters: PropTypes.object.isRequired,
-    filtersData: PropTypes.object.isRequired,
-  }
-
   const FilterByStatus = ({ filters, filtersData, allFundedIssues, allIssues }) => (
     <FilterDropDown
       caption="Status"
@@ -511,7 +474,6 @@ const FilterBar = ({
                   allIssues={allIssues}
                 />
                 <FilterByLabel filters={filters} filtersData={filtersData} />
-                <FilterByMilestone filters={filters} filtersData={filtersData} />
               </Overflow>
             </FilterBarMainLeft>
           </>

--- a/apps/projects/app/components/Shared/FilterBar/FilterBar.js
+++ b/apps/projects/app/components/Shared/FilterBar/FilterBar.js
@@ -27,12 +27,10 @@ import { usePanelManagement } from '../../Panel'
 import Label from '../../Content/IssueDetail/Label'
 import { issueShape } from '../../../utils/shapes.js'
 
-const sorters = [
-  'Created descending',
-  'Created ascending',
-  'Updated descending',
-  'Updated ascending',
-]
+const sorters = {
+  'updated-desc': 'Recently updated',
+  'updated-asc': 'Least recently updated',
+}
 
 const TextFilterInput = ({ textFilter, updateTextFilter }) => {
   const theme = useTheme()
@@ -127,7 +125,7 @@ const SortPopover = ({ visible, opener, setVisible, sortBy, updateSortBy }) => {
       placement="bottom-end"
     >
       <Label text="Sort by" />
-      {sorters.map(way => (
+      {Object.keys(sorters).map(way => (
         <FilterMenuItem
           key={way}
           onClick={updateSortBy(way)}
@@ -135,7 +133,7 @@ const SortPopover = ({ visible, opener, setVisible, sortBy, updateSortBy }) => {
           <div css={`width: ${3 * GU}px`}>
             {way === sortBy && <IconCheck color={`${theme.accent}`} />}
           </div>
-          <ActionLabel>{way}</ActionLabel>
+          <ActionLabel>{sorters[way]}</ActionLabel>
         </FilterMenuItem>
       ))}
     </Popover>
@@ -272,9 +270,7 @@ const FilterBar = ({
   selectedIssues,
   onSearchChange,
 }) => {
-
-  // Complete list of sorters for DropDown. Parent has only one item, to perform actual sorting.
-  const [ sortBy, setSortBy ] = useState(sorters[0])
+  const [ sortBy, setSortBy ] = useState(Object.keys(sorters)[0])
   const [ textFilter, setTextFilter ] = useState('')
   const [ sortMenuVisible, setSortMenuVisible ] = useState(false)
   const [ actionsMenuVisible, setActionsMenuVisible ] = useState(false)

--- a/apps/projects/app/components/Shared/FilterBar/FilterBar.js
+++ b/apps/projects/app/components/Shared/FilterBar/FilterBar.js
@@ -27,11 +27,6 @@ import { usePanelManagement } from '../../Panel'
 import Label from '../../Content/IssueDetail/Label'
 import { issueShape } from '../../../utils/shapes.js'
 
-const sorters = {
-  'updated-desc': 'Recently updated',
-  'updated-asc': 'Least recently updated',
-}
-
 const TextFilterInput = ({ textFilter, updateTextFilter }) => {
   const theme = useTheme()
 
@@ -113,7 +108,14 @@ TextFilter.propTypes = {
   updateTextFilter: PropTypes.func.isRequired,
 }
 
-const SortPopover = ({ visible, opener, setVisible, sortBy, updateSortBy }) => {
+const SortPopover = ({
+  visible,
+  opener,
+  setVisible,
+  sortBy,
+  sortOptions,
+  updateSortBy,
+}) => {
   const theme = useTheme()
 
   return (
@@ -125,7 +127,7 @@ const SortPopover = ({ visible, opener, setVisible, sortBy, updateSortBy }) => {
       placement="bottom-end"
     >
       <Label text="Sort by" />
-      {Object.keys(sorters).map(way => (
+      {Object.keys(sortOptions).map(way => (
         <FilterMenuItem
           key={way}
           onClick={updateSortBy(way)}
@@ -133,7 +135,7 @@ const SortPopover = ({ visible, opener, setVisible, sortBy, updateSortBy }) => {
           <div css={`width: ${3 * GU}px`}>
             {way === sortBy && <IconCheck color={`${theme.accent}`} />}
           </div>
-          <ActionLabel>{sorters[way]}</ActionLabel>
+          <ActionLabel>{sortOptions[way].name}</ActionLabel>
         </FilterMenuItem>
       ))}
     </Popover>
@@ -144,6 +146,7 @@ SortPopover.propTypes = {
   opener: PropTypes.object,
   setVisible: PropTypes.func.isRequired,
   sortBy: PropTypes.string.isRequired,
+  sortOptions: PropTypes.object.isRequired,
   updateSortBy: PropTypes.func.isRequired,
 }
 
@@ -269,8 +272,9 @@ const FilterBar = ({
   deselectAllIssues,
   selectedIssues,
   onSearchChange,
+  sortOptions,
+  sortBy,
 }) => {
-  const [ sortBy, setSortBy ] = useState(Object.keys(sorters)[0])
   const [ textFilter, setTextFilter ] = useState('')
   const [ sortMenuVisible, setSortMenuVisible ] = useState(false)
   const [ actionsMenuVisible, setActionsMenuVisible ] = useState(false)
@@ -336,7 +340,6 @@ const FilterBar = ({
 
   const updateSortBy = way => () => {
     handleSorting(way)
-    setSortBy(way)
     setSortMenuVisible(false)
   }
 
@@ -533,6 +536,7 @@ const FilterBar = ({
               opener={sortersOpener.current}
               setVisible={setSortMenuVisible}
               sortBy={sortBy}
+              sortOptions={sortOptions}
               updateSortBy={updateSortBy}
             />
 
@@ -578,6 +582,8 @@ FilterBar.propTypes = {
   selectedIssues: PropTypes.arrayOf(issueShape).isRequired,
   onSearchChange: PropTypes.func.isRequired,
   deselectAllIssues: PropTypes.func.isRequired,
+  sortBy: PropTypes.string.isRequired,
+  sortOptions: PropTypes.object.isRequired,
 }
 
 const FilterMenuItem = styled(ContextMenuItem)`

--- a/apps/projects/app/components/Shared/FilterBar/FilterBar.js
+++ b/apps/projects/app/components/Shared/FilterBar/FilterBar.js
@@ -382,8 +382,7 @@ const FilterBar = ({
                   uppercase={false}
                 >
                   {filtersData.labels[id].name}
-                </Tag>{' '}
-              ({filtersData.labels[id].count})
+                </Tag>
               </ActionLabel>
             </FilterMenuItem>
           )}
@@ -421,8 +420,7 @@ const FilterBar = ({
               />
             </div>
             <ActionLabel>
-              {filtersData.milestones[id].title} (
-              {filtersData.milestones[id].count})
+              {filtersData.milestones[id].title}
             </ActionLabel>
           </FilterMenuItem>
         ))}
@@ -450,8 +448,7 @@ const FilterBar = ({
             />
           </div>
           <ActionLabel>
-            {filtersData.statuses[status].name} (
-            {filtersData.statuses[status].count})
+            {filtersData.statuses[status].name}
           </ActionLabel>
         </FilterMenuItem>
       ))}
@@ -473,8 +470,7 @@ const FilterBar = ({
             />
           </div>
           <ActionLabel>
-            {filtersData.statuses[status].name} (
-            {filtersData.statuses[status].count})
+            {filtersData.statuses[status].name}
           </ActionLabel>
         </FilterMenuItem>
       ))}

--- a/apps/projects/app/components/Shared/FilterBar/FilterBar.js
+++ b/apps/projects/app/components/Shared/FilterBar/FilterBar.js
@@ -25,7 +25,7 @@ import { IconArrow as IconArrowDown } from '../../../../../../shared/ui'
 import { IconSort, IconGrid, IconCoins, IconFilter } from '../../../assets'
 import { usePanelManagement } from '../../Panel'
 import Label from '../../Content/IssueDetail/Label'
-import { issueShape } from '../../../utils/shapes.js'
+import { issueShape, repoShape } from '../../../utils/shapes.js'
 
 const TextFilterInput = ({ textFilter, updateTextFilter }) => {
   const theme = useTheme()
@@ -274,6 +274,7 @@ const FilterBar = ({
   onSearchChange,
   sortOptions,
   sortBy,
+  repo,
 }) => {
   const [ textFilter, setTextFilter ] = useState('')
   const [ sortMenuVisible, setSortMenuVisible ] = useState(false)
@@ -335,7 +336,7 @@ const FilterBar = ({
     // filters are in local state because of checkboxes
     // and sent to the parent (Issues) for actual display change
     setParentFilters({ filters })
-    handleFiltering(filters)
+    handleFiltering(filters, filtersData)
   }
 
   const updateSortBy = way => () => {
@@ -487,7 +488,7 @@ const FilterBar = ({
   // filtersData is about displayed checkboxes
   const allFundedIssues = [ 'funded', 'review-applicants', 'in-progress', 'review-work', 'fulfilled' ]
   const allIssues = [ 'all-funded', 'not-funded' ]
-  const filtersData = prepareFilters(issues, bountyIssues)
+  const filtersData = prepareFilters(issues, bountyIssues, repo)
 
   const actionsClickHandler = () =>
     selectedIssues.length && setActionsMenuVisible(true)
@@ -558,6 +559,7 @@ const FilterBar = ({
             filters={filters}
             disableFilter={disableFilter}
             disableAllFilters={disableAllFilters}
+            repo={repo}
           />
         </FilterBarActives>
       )}
@@ -580,6 +582,7 @@ FilterBar.propTypes = {
   deselectAllIssues: PropTypes.func.isRequired,
   sortBy: PropTypes.string.isRequired,
   sortOptions: PropTypes.object.isRequired,
+  repo: repoShape,
 }
 
 const FilterMenuItem = styled(ContextMenuItem)`

--- a/apps/projects/app/components/Shared/FilterBar/FilterBar.js
+++ b/apps/projects/app/components/Shared/FilterBar/FilterBar.js
@@ -28,10 +28,10 @@ import Label from '../../Content/IssueDetail/Label'
 import { issueShape } from '../../../utils/shapes.js'
 
 const sorters = [
-  'Name ascending',
-  'Name descending',
-  'Newest',
-  'Oldest',
+  'Created descending',
+  'Created ascending',
+  'Updated descending',
+  'Updated ascending',
 ]
 
 const TextFilterInput = ({ textFilter, updateTextFilter }) => {
@@ -274,7 +274,7 @@ const FilterBar = ({
 }) => {
 
   // Complete list of sorters for DropDown. Parent has only one item, to perform actual sorting.
-  const [ sortBy, setSortBy ] = useState('Newest')
+  const [ sortBy, setSortBy ] = useState(sorters[0])
   const [ textFilter, setTextFilter ] = useState('')
   const [ sortMenuVisible, setSortMenuVisible ] = useState(false)
   const [ actionsMenuVisible, setActionsMenuVisible ] = useState(false)
@@ -574,7 +574,6 @@ FilterBar.propTypes = {
   bountyIssues: PropTypes.arrayOf(issueShape).isRequired,
   issues: PropTypes.arrayOf(issueShape).isRequired,
   issuesFiltered: PropTypes.arrayOf(issueShape).isRequired,
-  sortBy: PropTypes.string.isRequired,
   handleFiltering: PropTypes.func.isRequired,
   handleSorting: PropTypes.func.isRequired,
   setParentFilters: PropTypes.func.isRequired,

--- a/apps/projects/app/components/Shared/FilterBar/prepareFilters.js
+++ b/apps/projects/app/components/Shared/FilterBar/prepareFilters.js
@@ -8,7 +8,6 @@ const prepareFilters = (issues, bountyIssues, repo) => {
   let filters = {
     projects: {},
     labels: {},
-    milestones: {},
     deadlines: {},
     experiences: {},
     statuses: {},
@@ -26,7 +25,6 @@ const prepareFilters = (issues, bountyIssues, repo) => {
     name: BOUNTY_STATUS['not-funded'],
   }
 
-  filters.milestones = repo.metadata.milestones
   filters.labels = repo.metadata.labels
 
   return filters

--- a/apps/projects/app/components/Shared/FilterBar/prepareFilters.js
+++ b/apps/projects/app/components/Shared/FilterBar/prepareFilters.js
@@ -4,7 +4,7 @@ import { BOUNTY_STATUS } from '../../../utils/bounty-status'
   prepareFilters builds data structure for displaying filterbar dropdowns
   data comes from complete issues array, issuesFiltered is used for counters
 */
-const prepareFilters = (issues, bountyIssues) => {
+const prepareFilters = (issues, bountyIssues, repo) => {
   let filters = {
     projects: {},
     labels: {},
@@ -26,41 +26,9 @@ const prepareFilters = (issues, bountyIssues) => {
     name: BOUNTY_STATUS['not-funded'],
   }
 
-  issues.map(issue => {
-    if (issue.milestone) {
-      if (!(issue.milestone.id in filters.milestones)) {
-        filters.milestones[issue.milestone.id] = issue.milestone
-      }
-    } else {
-      if (!('milestoneless' in filters.milestones)) {
-        filters.milestones['milestoneless'] = {
-          title: 'Issues without milestones',
-          id: 'milestoneless',
-        }
-      }
-    }
+  filters.milestones = repo.metadata.milestones
+  filters.labels = repo.metadata.labels
 
-    if (issue.labels.totalCount) {
-      issue.labels.edges.map(label => {
-        if (!(label.node.id in filters.labels)) {
-          filters.labels[label.node.id] = label.node
-        }
-      })
-    } else {
-      if (!('labelless' in filters.labels)) {
-        filters.labels['labelless'] = {
-          name: 'Issues without labels',
-          id: 'labelless',
-        }
-      }
-    }
-    // TODO: shouldn't it be reporitory.id?
-    if (!(issue.repository.id in filters.projects)) {
-      filters.projects[issue.repository.id] = {
-        name: issue.repository.name,
-      }
-    }
-  })
   return filters
 }
 

--- a/apps/projects/app/components/Shared/FilterBar/prepareFilters.js
+++ b/apps/projects/app/components/Shared/FilterBar/prepareFilters.js
@@ -17,67 +17,47 @@ const prepareFilters = (issues, bountyIssues) => {
   Object.keys(BOUNTY_STATUS).forEach(status =>
     filters.statuses[status] = {
       name: BOUNTY_STATUS[status],
-      count: 0,
     }
   )
   filters.statuses['all-funded'] = {
     name: BOUNTY_STATUS['all-funded'],
-    count: bountyIssues.length,
   }
   filters.statuses['not-funded'] = {
     name: BOUNTY_STATUS['not-funded'],
-    count: issues.length - bountyIssues.length,
   }
-  bountyIssues.map(issue => filters.statuses[issue.data.workStatus].count++)
 
   issues.map(issue => {
     if (issue.milestone) {
-      if (issue.milestone.id in filters.milestones) {
-        filters.milestones[issue.milestone.id].count++
-      } else {
-        filters.milestones[issue.milestone.id] = {
-          ...issue.milestone,
-          count: 1,
-        }
+      if (!(issue.milestone.id in filters.milestones)) {
+        filters.milestones[issue.milestone.id] = issue.milestone
       }
     } else {
-      if ('milestoneless' in filters.milestones) {
-        filters.milestones['milestoneless'].count++
-      } else {
+      if (!('milestoneless' in filters.milestones)) {
         filters.milestones['milestoneless'] = {
           title: 'Issues without milestones',
           id: 'milestoneless',
-          count: 1,
         }
       }
     }
 
     if (issue.labels.totalCount) {
       issue.labels.edges.map(label => {
-        if (label.node.id in filters.labels) {
-          filters.labels[label.node.id].count++
-        } else {
-          filters.labels[label.node.id] = { ...label.node, count: 1 }
+        if (!(label.node.id in filters.labels)) {
+          filters.labels[label.node.id] = label.node
         }
       })
     } else {
-      if ('labelless' in filters.labels) {
-        filters.labels['labelless'].count++
-      } else {
+      if (!('labelless' in filters.labels)) {
         filters.labels['labelless'] = {
           name: 'Issues without labels',
           id: 'labelless',
-          count: 1,
         }
       }
     }
     // TODO: shouldn't it be reporitory.id?
-    if (issue.repository.id in filters.projects) {
-      filters.projects[issue.repository.id].count++
-    } else {
+    if (!(issue.repository.id in filters.projects)) {
       filters.projects[issue.repository.id] = {
         name: issue.repository.name,
-        count: 1,
       }
     }
   })

--- a/apps/projects/app/context/BountyIssues.js
+++ b/apps/projects/app/context/BountyIssues.js
@@ -35,20 +35,7 @@ export function BountyIssuesProvider(props) {
     })
 
     client.request(getIssues(issues.map(i => i.data.issueId)))
-      .then(({ nodes }) => {
-        const now = new Date()
-        setBountyIssues(nodes.map(shapeIssue).sort((a, b) => {
-          //If a deadline has expired, most recent deadline first
-          //If a deadline upcoming, closest to the deadline first
-          let aDate = new Date(a.deadline)
-          let bDate = new Date(b.deadline)
-          if (aDate < now || bDate < now) {
-            aDate = now - aDate
-            bDate = now - bDate
-          }
-          return aDate - bDate
-        }))
-      })
+      .then(data => setBountyIssues(data.nodes.map(shapeIssue)))
       .catch(console.error)
   }, [ github.token, issues ])
 

--- a/apps/projects/app/context/DecoratedRepos.js
+++ b/apps/projects/app/context/DecoratedRepos.js
@@ -9,6 +9,24 @@ const repoQuery = repoId => `{
       url
       description
       owner { login }
+      labels(first: 100) {
+        totalCount
+        edges {
+          node {
+            id
+            name
+            color
+          }
+        }
+      }
+      milestones(first: 100) {
+        edges {
+          node {
+            id
+            title
+          }
+        }
+      }
       defaultBranchRef {
         target {
           ...on Commit {
@@ -68,6 +86,14 @@ export function DecoratedReposProvider(props) {
               commits: node.defaultBranchRef
                 ? node.defaultBranchRef.target.history.totalCount
                 : 0,
+              labels: node.labels.edges.reduce((map, label) => {
+                map[label.node.id] = label.node
+                return map
+              }, {}),
+              milestones: node.milestones.edges.reduce((map, milestone) => {
+                map[milestone.node.id] = milestone.node
+                return map
+              }, {}),
             },
           }))
           .catch(err => ({

--- a/apps/projects/app/context/DecoratedRepos.js
+++ b/apps/projects/app/context/DecoratedRepos.js
@@ -8,6 +8,7 @@ const repoQuery = repoId => `{
       name
       url
       description
+      owner { login }
       defaultBranchRef {
         target {
           ...on Commit {
@@ -57,6 +58,7 @@ export function DecoratedReposProvider(props) {
             data: { _repo: repo.data._repo },
             metadata: {
               name: node.name,
+              owner: node.owner.login,
               url: node.url,
               description: node.description
                 ? node.description

--- a/apps/projects/app/context/DecoratedRepos.js
+++ b/apps/projects/app/context/DecoratedRepos.js
@@ -19,14 +19,6 @@ const repoQuery = repoId => `{
           }
         }
       }
-      milestones(first: 100) {
-        edges {
-          node {
-            id
-            title
-          }
-        }
-      }
       defaultBranchRef {
         target {
           ...on Commit {
@@ -88,10 +80,6 @@ export function DecoratedReposProvider(props) {
                 : 0,
               labels: node.labels.edges.reduce((map, label) => {
                 map[label.node.id] = label.node
-                return map
-              }, {}),
-              milestones: node.milestones.edges.reduce((map, milestone) => {
-                map[milestone.node.id] = milestone.node
                 return map
               }, {}),
             },

--- a/apps/projects/app/utils/gql-queries.js
+++ b/apps/projects/app/utils/gql-queries.js
@@ -34,14 +34,19 @@ export const issueAttributes = `
 `
 
 export const getIssuesGQL =  gql`
-  query GetIssuesForRepo($repoId: ID!, $after: String)  {
+  query GetIssuesForRepo(
+    $repoId: ID!,
+    $after: String,
+    $sortField: String!,
+    $sortOrder: String!
+  )  {
     repository: node(id: $repoId) {
       ... on Repository {
         issues(
           states:OPEN,
           first: 25,
           after: $after,
-          orderBy: {field: CREATED_AT, direction: DESC}
+          orderBy: { field: $sortField, direction: $sortOrder }
         ) {
           totalCount
           pageInfo {

--- a/apps/projects/app/utils/gql-queries.js
+++ b/apps/projects/app/utils/gql-queries.js
@@ -11,6 +11,7 @@ export const issueAttributes = `
     url
   }
   createdAt
+  updatedAt
   repository {
     id
     name

--- a/apps/projects/app/utils/gql-queries.js
+++ b/apps/projects/app/utils/gql-queries.js
@@ -34,12 +34,12 @@ export const issueAttributes = `
 `
 
 export const getIssuesGQL =  gql`
-  query GetIssuesForRepo($repoId: ID!, $count: Int, $after: String)  {
+  query GetIssuesForRepo($repoId: ID!, $after: String)  {
     repository: node(id: $repoId) {
       ... on Repository {
         issues(
           states:OPEN,
-          first: $count,
+          first: 25,
           after: $after,
           orderBy: {field: CREATED_AT, direction: DESC}
         ) {

--- a/apps/projects/app/utils/gql-queries.js
+++ b/apps/projects/app/utils/gql-queries.js
@@ -34,7 +34,7 @@ export const issueAttributes = `
   url
 `
 
-export const SEARCH_ISSUES =  gql`
+export const SEARCH_ISSUES = gql`
   query SearchIssues($after: String, $query: String!) {
     search(
       after:$after,

--- a/apps/projects/app/utils/gql-queries.js
+++ b/apps/projects/app/utils/gql-queries.js
@@ -33,28 +33,20 @@ export const issueAttributes = `
   url
 `
 
-export const getIssuesGQL =  gql`
-  query GetIssuesForRepo(
-    $repoId: ID!,
-    $after: String,
-    $sortField: String!,
-    $sortOrder: String!
-  )  {
-    repository: node(id: $repoId) {
-      ... on Repository {
-        issues(
-          states:OPEN,
-          first: 25,
-          after: $after,
-          orderBy: { field: $sortField, direction: $sortOrder }
-        ) {
-          totalCount
-          pageInfo {
-            endCursor
-            hasNextPage
-          }
-          nodes { ${issueAttributes} }
-        }
+export const SEARCH_ISSUES =  gql`
+  query SearchIssues($after: String, $query: String!) {
+    search(
+      after:$after,
+      first:25,
+      query:$query,
+      type:ISSUE,
+    ) {
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+      issues:nodes {
+        ... on Issue { ${ issueAttributes } }
       }
     }
   }

--- a/apps/projects/app/utils/gql-queries.js
+++ b/apps/projects/app/utils/gql-queries.js
@@ -33,14 +33,14 @@ export const issueAttributes = `
   url
 `
 
-export const getIssuesGQL = ({ repoId, count, after }) => gql`
-  query getIssuesForRepo {
-    repository: node(id: "${repoId}") {
+export const getIssuesGQL =  gql`
+  query GetIssuesForRepo($repoId: ID!, $count: Int, $after: String)  {
+    repository: node(id: $repoId) {
       ... on Repository {
         issues(
           states:OPEN,
-          first: ${count},
-          ${after ? `after: "${after}",` : ''}
+          first: $count,
+          after: $after,
           orderBy: {field: CREATED_AT, direction: DESC}
         ) {
           totalCount

--- a/apps/projects/app/utils/gql-queries.js
+++ b/apps/projects/app/utils/gql-queries.js
@@ -26,10 +26,6 @@ export const issueAttributes = `
       }
     }
   }
-  milestone {
-    id
-    title
-  }
   state
   url
 `

--- a/apps/projects/app/utils/shapes.js
+++ b/apps/projects/app/utils/shapes.js
@@ -35,4 +35,16 @@ const userGitHubShape = PropTypes.shape({
   login: PropTypes.string.isRequired,
 }).isRequired
 
-export { issueShape, userGitHubShape }
+const repoShape = PropTypes.shape({
+  data: PropTypes.shape({
+    _repo: PropTypes.string,
+  }),
+  metadata: PropTypes.shape({
+    name: PropTypes.string,
+    owner: PropTypes.string,
+    labels: PropTypes.object.isRequired,
+    milestones: PropTypes.object.isRequired,
+  })
+}).isRequired
+
+export { issueShape, repoShape, userGitHubShape }

--- a/apps/projects/app/utils/shapes.js
+++ b/apps/projects/app/utils/shapes.js
@@ -43,7 +43,6 @@ const repoShape = PropTypes.shape({
     name: PropTypes.string,
     owner: PropTypes.string,
     labels: PropTypes.object.isRequired,
-    milestones: PropTypes.object.isRequired,
   })
 }).isRequired
 


### PR DESCRIPTION
Everything has been implemented according to the idea. Effect: pagination works. Downloading issues from GH is fast enough (not blindingly, but it is better than it used to be, especially with pagination). However... there are challenges discovered along the way:
1. Labels can be used for filtering issues easily: 

`filterBy: { labels: ["bug", "app: projects"]}`

Filtering by milestones doesn't work that way. When we discuss all of it, we may need to decide to take out milestones completely.

2. Text search is not compatible with filtering by labels. Filtering in normal `query` realized with `filterBy` (as above) does not provide any mean for filtering issues by title. What was intended: using `search` query like this:
```
    search(
      query:"is:issue state:open ${text to search for} in:title label:bug label:enhancement",
    ) {
```
the problem is, when there is more than one label, it searches for issues with _all_ the labels - that's different to what we do now, which is searching for issues with any of the labels.
In other words, `label:bug label:enhancement` will select issues with both of those labels, and in projects app selecting "bug" and "enhancement" from Labels dropdown will select issues with any of them.
This required using different queries for filtering by labels and text search. More complication in the code. And then another problem was discovered: text filtering uses whole words. It looks like this:

![Aragon-_1_](https://user-images.githubusercontent.com/34452131/73408954-1a625600-42fe-11ea-9e7b-01ce09db6f01.gif)

There is also quite a lot of flickering. Some of the causes were addressed in the old FilterBar related tickets, which got discussed but never merged.

# Goals:

- [x] use standard `gql` syntax
- [x] remove `ProjectDetailQuery` component
- [x] improve page load time (load 25 issues at a time)
- [x] improve "Show More" behavior
  ![issue paging improvements 2020-01-24 at 15 49 28](https://user-images.githubusercontent.com/221614/73103070-352d6880-3ec1-11ea-9d3c-0ae296febd01.gif)
- [x] make filtering update query, not filter client-side
- [x] show all labels & milestones for repo, not only those from current issue set