### PR TITLE
fix(recovery script): error on invalid allocations period length

### DIFF
--- a/templates/open-enterprise/scripts/recover-dao.js
+++ b/templates/open-enterprise/scripts/recover-dao.js
@@ -96,8 +96,8 @@ const getQuorum = (minSupport) => {
 const getAllocationsPeriod = () => {
   return new Promise((resolve) => {
     rl.question('enter the allocations period duration, in days > ', async (answer) => {
-      if (answer <= 0) {
-        rl.write('Error: Allocations budgeting period must be greater than zero\n')
+      if (answer < 1) {
+        rl.write('Error: Allocations budgeting period must be one day or longer\n')
         resolve(await getAllocationsPeriod())
       }
       resolve(answer * 24 * 60 * 60)


### PR DESCRIPTION
Prevents invalid allocations periods from being entered into the data string generator for dao recoveries.

Addresses the issue @macor161 found in #1916 