### PR TITLE
fix:  Very small dot-voting participation rounded

### DIFF
--- a/apps/dot-voting/app/components/VoteDetails/Participation.js
+++ b/apps/dot-voting/app/components/VoteDetails/Participation.js
@@ -8,7 +8,7 @@ import VotingOption from '../VotingOption'
 const Participation = ({ vote }) => {
   const theme = useTheme()
   const { appState: { globalMinQuorum = 0 } } = useAragonApi()
-  const minQuorum = globalMinQuorum / 10 ** 16
+  const minQuorum = parseInt((globalMinQuorum / 10 ** 16).toFixed(4))
   return (
     <Box heading="Participation" padding={0}>
       <div css={`padding: ${2 * GU}px ${3 * GU}px ${3 * GU}px ${3 * GU}px`}>


### PR DESCRIPTION
Fixes #1946 

Since a _very_ small participation is needed (can't be _true_ 0) We must round present the desired display value.

![Screenshot from 2020-01-28 12-08-20](https://user-images.githubusercontent.com/6549550/73287258-fd773700-41c6-11ea-9e9b-90c3aa366b89.png)
