### PR TITLE
fix(dot-voting): dark mode support for voting bars

### DIFF
--- a/apps/dot-voting/app/components/Slider.js
+++ b/apps/dot-voting/app/components/Slider.js
@@ -15,6 +15,7 @@ class Slider extends React.Component {
     value: PropTypes.number,
     onUpdate: PropTypes.func,
     width: PropTypes.string,
+    theme: PropTypes.object,
   }
   static defaultProps = {
     value: 0,
@@ -127,7 +128,7 @@ class Slider extends React.Component {
               onTouchStart={this.dragStart}
             >
               <Bars>
-                <BaseBar />
+                <BaseBar theme={this.props.theme} />
                 <ActiveBar
                   pressed={Number(pressed)}
                   style={this.getActiveBarStyles(value, pressProgress)}
@@ -186,7 +187,7 @@ const Bar = styled(animated.div)`
 `
 
 const BaseBar = styled(Bar)`
-  background: #edf3f6;
+  background: ${({ theme }) => theme.surfaceUnder};
 `
 
 const ActiveBar = styled(Bar)`

--- a/apps/dot-voting/app/components/VoteDetails/CastVote/EditVoteOption.js
+++ b/apps/dot-voting/app/components/VoteDetails/CastVote/EditVoteOption.js
@@ -67,6 +67,7 @@ const EditVoteOption = ({
         <Slider
           onUpdate={x => onUpdate(Math.round(x * 100))}
           value={value / 100}
+          theme={theme}
         />
         <HiddenLabel htmlFor={`percentage-${label}`}>Percentage</HiddenLabel>
         <TextInput

--- a/apps/dot-voting/app/components/VotingOption.js
+++ b/apps/dot-voting/app/components/VotingOption.js
@@ -76,7 +76,7 @@ const VotingOption = ({ valueSpring, label, percentage, allocation, color, thres
           position: relative;
         `}
       >
-        <BarWrapper>
+        <BarWrapper theme={theme}>
           <Bar
             style={{
               transform: valueSpring.interpolate(v => `scale3d(${v}, 1, 1)`),
@@ -124,7 +124,7 @@ const Labels = styled.div`
 
 const BarWrapper = styled.div`
   overflow: hidden;
-  background: #edf3f6;
+  background: ${({ theme }) => theme.surfaceUnder};
   border-radius: 2px;
   position: relative;
   width: 100%;


### PR DESCRIPTION
This removes the hardcoded values for the voting bars:
![Screenshot from 2020-01-29 10-57-57](https://user-images.githubusercontent.com/19808076/73373175-4cd06c80-4286-11ea-98db-1deace11303d.png)
