### PR TITLE
fix: make start:dev script work again

### DIFF
--- a/templates/dev/scripts/deploy.js
+++ b/templates/dev/scripts/deploy.js
@@ -1,6 +1,6 @@
 /* global artifacts, web3 */
 // const deployTemplate = require('@aragon/templates-shared/scripts/deploy-template')
-const deployTemplate = require('../../open-enterprise/temp/scripts/deploy-template')
+const deployTemplate = require('../temp/scripts/deploy-template')
 
 const TEMPLATE_NAME = 'open-enterprise-template'
 const CONTRACT_NAME = 'DevTemplate'

--- a/templates/dev/temp/helpers/apps.js
+++ b/templates/dev/temp/helpers/apps.js
@@ -1,0 +1,38 @@
+const { hash: namehash } = require('eth-ens-namehash')
+
+const ARAGON_APPS = [
+  { name: 'agent', contractName: 'Agent' },
+  { name: 'vault', contractName: 'Vault' },
+  { name: 'voting', contractName: 'Voting' },
+  //   { name: 'survey', contractName: 'Survey' },
+  //   { name: 'payroll', contractName: 'Payroll' },
+  { name: 'finance', contractName: 'Finance' },
+  { name: 'token-manager', contractName: 'TokenManager' },
+  //{ name: 'whitelist-oracle', contractName: 'WhitelistOracle' },
+  // { name: 'token-manager.hatch', contractName: 'TokenManager' },
+  // { name: 'whitelist-oracle.hatch', contractName: 'WhitelistOracle' },
+]
+  
+const ARAGON_APP_IDS = ARAGON_APPS.reduce((ids, { name }) => {
+  ids[name] = namehash(`${name}.aragonpm.eth`)
+  return ids
+}, {})
+
+const OE_APPS = [
+  { name: 'address-book', contractName: 'AddressBook' },
+  { name: 'allocations', contractName: 'Allocations' },
+  { name: 'discussions', contractName: 'DiscussionApp' },
+  { name: 'dot-voting', contractName: 'DotVoting' },
+  { name: 'projects', contractName: 'Projects' },
+  { name: 'rewards', contractName: 'Rewards' },
+]
+
+const OE_APP_IDS = OE_APPS.reduce((ids, { name }) => {
+  ids[name] = namehash(`${name}.aragonpm.eth`)
+  return ids
+}, {})
+
+module.exports = {
+  APPS: [ ...ARAGON_APPS, ...OE_APPS ],
+  APP_IDS: { ...ARAGON_APP_IDS, ...OE_APP_IDS }
+}

--- a/templates/dev/temp/scripts/deploy-template.js
+++ b/templates/dev/temp/scripts/deploy-template.js
@@ -1,0 +1,31 @@
+const { APPS } = require('../helpers/apps')
+const getAccounts = require('@aragon/os/scripts/helpers/get-accounts')
+const TemplatesDeployer = require('../../../open-enterprise/temp/lib/OEDeployer')
+
+const errorOut = message => {
+  console.error(message)
+  throw new Error(message)
+}
+
+module.exports = async function deployTemplate(web3, artifacts, templateName, contractName, apps = APPS) {
+  let { ens, owner, verbose, daoFactory, miniMeFactory, standardBounties, register } = require('yargs')
+    .option('e', { alias: 'ens', describe: 'ENS address', type: 'string' })
+    .option('o', { alias: 'owner', describe: 'Sender address. Will use first address if no one is given.', type: 'string' })
+    .option('v', { alias: 'verbose', describe: 'Verbose mode', type: 'boolean', default: true })
+    .option('df', { alias: 'dao-factory', describe: 'DAO Factory address. Will deploy new instance if not given.', type: 'string' })
+    .option('mf', { alias: 'mini-me-factory', describe: 'MiniMe Factory address. Will deploy new instance if not given.', type: 'string' })
+    .option('s', { alias: 'standard-bounties', describe: 'StandardBounties address. Will deploy new instance if not given', type: 'string' })
+    .option('r', { alias: 'register', describe: 'Whether the script will register the packages to aragon', type: 'boolean', default: true })
+    .help('help')
+    .parse()
+
+  if (!web3) errorOut('Missing "web3" object. This script must be run with a "web3" object globally defined, for example through "truffle exec".')
+  if (!artifacts) errorOut('Missing "artifacts" object. This script must be run with an "artifacts" object globally defined, for example through "truffle exec".')
+  if (!owner) owner = (await getAccounts(web3))[0]
+  if (!owner) errorOut('Missing sender address. Please specify one using "--owner" or make sure your web3 instance has one loaded.')
+  if (!templateName) errorOut('Missing template id.')
+  if (!contractName) errorOut('Missing template contract name.')
+
+  const deployer = new TemplatesDeployer(web3, artifacts, owner, { apps, ens, verbose, daoFactory, miniMeFactory, standardBounties, register })
+  return deployer.deploy(templateName, contractName)
+}


### PR DESCRIPTION
This is a temporary measure to unblock development from dev branch, it just removes the custom token-manager and whitelist from the dev-template, since this template was not updated yet to use this feature.

As this is temporary, some of the script files were copied as they are, the only actual modifications were adjusting the import path and replacing token-manager-custom by regular aragon token-manager and removing whitelist-oracle.