### PR TITLE
fix: reset remaining budget for new period and fix hard coded duration

### DIFF
--- a/apps/allocations/app/app-state-reducer.js
+++ b/apps/allocations/app/app-state-reducer.js
@@ -19,7 +19,9 @@ const getTokenFromAddress = (tokenAddress, tokenList) => {
 }
 
 function appStateReducer(state) {
-  const { accounts: budgets, balances , allocations } = state || {}
+  const { accounts: budgets, balances , allocations, period } = state || {}
+  const { endDate } = period || {}
+  const currentDate = new Date()
 
   const balancesBn = balances
     ? balances
@@ -43,7 +45,10 @@ function appStateReducer(state) {
       ...budget,
       active: budget.hasBudget && Number(budget.amount) > 0,
       // get some extra info about the token
-      token: getTokenFromAddress(budget.token, balances)
+      token: getTokenFromAddress(budget.token, balances),
+      // if current period end date is less than now, current period is over
+      // but not updated on chain. so we reset the remaining budget
+      remaining: endDate < currentDate ? budget.amount : budget.remaining,
       // amount: new BigNumber(budget.amount),
       // numData: {
       //   amount: parseInt(budget.amount, 10),

--- a/apps/allocations/app/components/App/BudgetDetail.js
+++ b/apps/allocations/app/components/App/BudgetDetail.js
@@ -27,6 +27,8 @@ import BudgetContextMenu from '../BudgetContextMenu'
 import { formatDate } from '../../utils/helpers'
 import * as types from '../../utils/prop-types'
 
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
 const percentOf = (smaller, bigger) =>
   `${BigNumber(100 * smaller / bigger).dp(1).toString()}%`
 
@@ -36,6 +38,15 @@ const displayCurrency = (amount, decimals) => {
     .dp(3)
     .toNumber()
     .toLocaleString()
+}
+
+const processTime = ms => {
+  const days = Math.round(ms/MS_PER_DAY)
+  if(days%7 === 0){
+    const weeks = days/7
+    return `per ${weeks === 1 ? 'week' : `${String(weeks)} weeks`}`
+  }
+  return `per ${days === 1 ? 'day' : `${String(days)} days`}`
 }
 
 const Grid = styled.div`
@@ -100,7 +111,7 @@ export default function BudgetDetail({ budget }) {
                     title="Budget"
                     large={displayCurrency(budget.amount, budget.token.decimals)}
                     small={budget.token.symbol}
-                    context="per 30 days"
+                    context={processTime(period.duration)}
                   />
                   <InfoBlock
                     style={{ flex: 1 }}


### PR DESCRIPTION
This PR fixes two things:
1) It removes the hardcoded 'per 30 days' in BudgetDetails and sets it based on period.duration
2) If the current time is past the endDate time of the contract period. the budget remaining is set to the full budget amount. this way users can allocate funds after the period has ended