### PR TITLE
fix(allocations): distributions with zero-support candidates

### DIFF
--- a/apps/allocations/app/store/allocation.js
+++ b/apps/allocations/app/store/allocation.js
@@ -110,9 +110,9 @@ const getAllocation = async ({ accountId, payoutId }) => {
         token,
         date: new Date(startTime*1000),
         recipients,
-        status: recipients.every(r => r.executions === recurrences)
+        status: recipients.every(r => r.executions === recurrences || r.supports === '0')
           ? STATUS_ENACTED
-          : STATUS_APPROVED, //Approved will be made dynamic once the execution handler is integrated
+          : STATUS_APPROVED,
       }))
     )
     .toPromise()


### PR DESCRIPTION
when all payout funds are transferred for a given allocation,
the allocation should be marked as "enacted". However, candidates
with zero support cannot execute and therefor cannot meet the execution
condition, so a special case should be made for them to ensure
the payout is marked as "enacted" instead of just "approved"