### PR TITLE
fix: add period advancement to set distribution function

### DIFF
--- a/apps/allocations/contracts/Allocations.sol
+++ b/apps/allocations/contracts/Allocations.sol
@@ -431,7 +431,11 @@ contract Allocations is AragonApp {
         uint64 _startTime,
         uint64 _period,
         uint256 _amount
-    ) public auth(CREATE_ALLOCATION_ROLE) returns(uint64 payoutId)
+    )
+    public
+    auth(CREATE_ALLOCATION_ROLE)
+    transitionsPeriod
+    returns(uint64 payoutId)
     {
         require(maxCandidates >= _candidateAddresses.length); // solium-disable-line error-reason
         Account storage account = accounts[_accountId];


### PR DESCRIPTION
This PR makes a contract change by adding the `transitionsPeriod` modifier to `setDistribution` which will allow the period to advance when funds are allocated via Dot Voting.