### PR TITLE
fix: allocations panel help dialog uses correct period

### DIFF
--- a/apps/allocations/app/components/Panel/NewAllocation.js
+++ b/apps/allocations/app/components/Panel/NewAllocation.js
@@ -15,6 +15,7 @@ import web3Utils from 'web3-utils'
 import styled from 'styled-components'
 import { BigNumber } from 'bignumber.js'
 
+import usePeriod from '../../hooks/usePeriod'
 import { addressesEqual } from '../../../../../shared/lib/web3-utils'
 import { RecipientsInput } from '../../../../../shared/ui'
 import { MIN_AMOUNT } from '../../utils/constants'
@@ -95,7 +96,8 @@ DescriptionField.propTypes = {
 
 function AmountField({ budget, onChange, value, token }) {
   const theme = useTheme()
-  const { balances, period } = useAragonApi().appState
+  const { balances } = useAragonApi().appState
+  const period = usePeriod()
   const periodEndDate = formatDate({ date: period.endDate, short: true })
 
   const remainingBudget = BigNumber(budget.remaining)


### PR DESCRIPTION
The NewAllocations panel was not using the `usePeriod` hook to get the current period. This PR just updates the panel to use that hook.