### PR TITLE
fix(allocations): frontend period and budget remaining override

### DIFF
--- a/apps/allocations/app/components/App/BudgetDetail.js
+++ b/apps/allocations/app/components/App/BudgetDetail.js
@@ -74,6 +74,11 @@ export default function BudgetDetail({ budget }) {
   const { newAllocation } = usePanel()
   const period = usePeriod()
   const theme = useTheme()
+  const { period: onchainPeriod } = appState
+
+  if (onchainPeriod.endDate < new Date()) {
+    budget.remaining = budget.amount
+  }
 
   const allocations = (appState.allocations || [])
     .filter(a => a.accountId === budget.id)

--- a/apps/allocations/app/components/Card/Budget.js
+++ b/apps/allocations/app/components/Card/Budget.js
@@ -15,12 +15,18 @@ import {
   Text,
   useTheme,
 } from '@aragon/ui'
+import { useAppState } from '@aragon/api-react'
 
 const Budget = ({ budget }) => {
   const theme = useTheme()
+  const { period: onchainPeriod } = useAppState()
   const { active, amount, remaining, token } = budget
+  let calculatedRemaining = remaining
+  if (onchainPeriod.endDate < new Date() ) {
+    calculatedRemaining = amount
+  }
 
-  const tokensSpent = BigNumber(amount).minus(remaining)
+  const tokensSpent = BigNumber(amount).minus(calculatedRemaining)
 
   return (
     <Wrapper budget={budget} theme={theme}>


### PR DESCRIPTION
Sometimes the app state reducer doesn't kick in to globally override the
remaining budget. These calculations in the frontend components ensure
the remaining budget is set to zero if the onchain period end date has
passed. (because an un-transitioned accounting period indicates that no
    funds have been spent since the last cycle)