### PR TITLE
fix(allocations): update budget state on period transition

### DIFF
--- a/apps/allocations/app/store/account.js
+++ b/apps/allocations/app/store/account.js
@@ -10,6 +10,7 @@ import { combineLatest } from 'rxjs'
 
 export const updateAccounts = async (accounts, id) => {
   const newAccounts = Array.from(accounts || [])
+  if (!id) return syncAccounts(newAccounts)
   const accountIdx = newAccounts.findIndex(a => a.id === id)
   if (accountIdx === -1) {
     newAccounts.push(await getAccount(id))
@@ -18,6 +19,11 @@ export const updateAccounts = async (accounts, id) => {
     newAccounts[accountIdx] = await getAccount(id)
   }
   return newAccounts
+}
+
+const syncAccounts = async (accounts = []) => {
+  const syncedAccounts = accounts.map(async account => await getAccount(account.id))
+  return Promise.all(syncedAccounts)
 }
 
 // const onNewPayout = async (payouts = [], { accountId, payoutId }) => {

--- a/apps/allocations/app/store/events.js
+++ b/apps/allocations/app/store/events.js
@@ -47,6 +47,7 @@ const eventHandler = async eventData => {
   case 'NewPeriod':
     return {
       ...state,
+      accounts: await updateAccounts(state.accounts),
       period: {
         id: returnValues.periodId,
         startDate: new Date(returnValues.periodStarts * 1000),


### PR DESCRIPTION
When a period transitioned, The budget state was not updating
in the frontend and actually reverts to reflecting the last active
period's state. This update pulls in the updated budget contract state
after a period's state changes onchain. frontend logic  for reflecting
budget state before a transition is still sound and not encompassed
in these changes