### PR TITLE
fix(rewards-store): don't call fetch if its not available

### DIFF
--- a/apps/rewards/app/store/events.js
+++ b/apps/rewards/app/store/events.js
@@ -39,6 +39,10 @@ export const handleEvent = async (state, event, settings) => {
   }
 
   nextState = { ...state, ...nextState }
-  nextState.convertRates = await updateConvertedRates(state)
+  // check if fetch is accessible to script.js
+  // if not we can fallback on getting conversion rates
+  // in the frontend
+  if (typeof fetch === 'function') 
+    nextState.convertRates = await updateConvertedRates(state)
   return nextState
 }


### PR DESCRIPTION
if fetch isn't available in the script context, conversion rates can be
fetched from the frontend as a fallback